### PR TITLE
Change Index Page With Redirect Example

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -1,4 +1,5 @@
 import { prismicClient } from "src/prismic.config"
+import Prismic from "prismic-javascript"
 
 export default function IndexPage() {
   return null
@@ -14,7 +15,9 @@ export default function IndexPage() {
 export async function getServerSideProps() {
   const {
     results: [page],
-  } = await prismicClient.query("")
+  } = await prismicClient.query(
+    Prismic.Predicates.at("document.tags", ["production"])
+  )
   if (page) {
     return {
       redirect: {

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,28 +1,32 @@
-import { Router } from "next/router"
 import { prismicClient } from "src/prismic.config"
 
-const IndexPage = () => {
+export default function IndexPage() {
   return null
 }
 
-/** TODO: Come up with a tag to indicate "production" pages in CMS and
- *        redirect to the first "production" page instead */
-const possibleLandingPages = ["listings-100001", "listings"]
+/**
+ * TODO: Indicate production pages with a tag.
+ * Redirect to first production page instead of hard coding it with an array.
+ */
 
-IndexPage.getInitialProps = async ({ res }) => {
-  const { results: pages } = await prismicClient.query("")
+// const landingPages = ["listings"]
 
-  const landingPage =
-    pages.find((page) => possibleLandingPages.includes(page.uid)) || pages[0]
-
-  if (res) {
-    res.writeHead(302, { Location: `/${landingPage.type}/${landingPage.uid}` })
-    res.end()
-    return {}
+export async function getServerSideProps() {
+  const {
+    results: [page],
+  } = await prismicClient.query("")
+  if (page) {
+    return {
+      redirect: {
+        destination: `/${page.type}/${page.uid}`,
+        permanent: false,
+      },
+    }
   }
-
-  Router.push(`/info/${landingPage.uid}`)
-  return {}
+  return {
+    redirect: {
+      destination: "/info/listings",
+      permanent: false,
+    },
+  }
 }
-
-export default IndexPage

--- a/pages/info/[uid].js
+++ b/pages/info/[uid].js
@@ -14,9 +14,9 @@ import {
 export const getStaticProps = async ({
   preview = null,
   previewData = {},
-  params: { type, uid },
+  params: { uid },
 }) => {
-  const data = await prismicClient.getByUID(type, uid, { ...previewData })
+  const data = await prismicClient.getByUID("info", uid, { ...previewData })
   return {
     props: {
       preview,
@@ -29,7 +29,7 @@ export const getStaticProps = async ({
 
 export const getStaticPaths = async () => {
   const pages = await prismicClient.query("", { pageSize: 100 })
-  const paths = pages.results.map((p) => `/${p.type}/${p.uid}`)
+  const paths = pages.results.map((p) => `/info/${p.uid}`)
   return { paths, fallback: false }
 }
 


### PR DESCRIPTION
Hey @quaardvark ,

I've updated the index page to use the new (not well documented) redirect return from any of the `getXProps` functions.

I've also added the start of a code standards list to the README on master.