### PR TITLE
Refactor NavBar to simplify the input required and to facilitate "automatic" responsiveness

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -10,6 +10,7 @@
   "rules": {
     "prettier/prettier": ["error"],
     "no-console": "off",
+    "no-underscore-dangle": [0],
     "no-unused-vars": [1, { "args": "after-used", "ignoreRestSiblings": true }],
     "quotes": [1, "double", { "allowTemplateLiterals": true }],
     "semi": [1, "never"],

--- a/pages/info/[uid].js
+++ b/pages/info/[uid].js
@@ -92,12 +92,15 @@ const Page = ({ data, uid }) => {
 
   const navBarLinks =
     data.nav_bar &&
-    data.nav_bar.map(({ buttonText, buttonLink, buttonHash, primary }) => ({
-      text: buttonText,
-      href: buttonHash ? `#${buttonHash.replace(/^#/, "")}` : buttonLink.url,
-      target: buttonLink && buttonLink.target,
-      primary,
-    }))
+    data.nav_bar.map(
+      ({ buttonText, buttonLink, buttonHash, primary, push }) => ({
+        text: buttonText,
+        href: buttonHash ? `#${buttonHash.replace(/^#/, "")}` : buttonLink.url,
+        target: buttonLink && buttonLink.target,
+        primary,
+        push,
+      })
+    )
   return (
     <UrlResolverProvider params={urlResolverParams}>
       <NextSeo

--- a/pages/info/[uid].js
+++ b/pages/info/[uid].js
@@ -92,15 +92,12 @@ const Page = ({ data, uid }) => {
 
   const navBarLinks =
     data.nav_bar &&
-    data.nav_bar.map(
-      ({ buttonText, buttonLink, buttonHash, primary, push, breakpoint }) => ({
-        text: buttonText,
-        href: buttonHash ? `#${buttonHash.replace(/^#/, "")}` : buttonLink.url,
-        primary,
-        push,
-        breakpoint,
-      })
-    )
+    data.nav_bar.map(({ buttonText, buttonLink, buttonHash, primary }) => ({
+      text: buttonText,
+      href: buttonHash ? `#${buttonHash.replace(/^#/, "")}` : buttonLink.url,
+      target: buttonLink && buttonLink.target,
+      primary,
+    }))
   return (
     <UrlResolverProvider params={urlResolverParams}>
       <NextSeo

--- a/src/components/molecules/PitchCard/index.js
+++ b/src/components/molecules/PitchCard/index.js
@@ -3,6 +3,7 @@ import Link from "next/link"
 import { Button } from "@rent_avail/controls"
 import { Text } from "@rent_avail/typography"
 import * as React from "react"
+import { getTargetProps } from "utils/link"
 
 export function PitchCard({
   title = "",
@@ -35,19 +36,11 @@ export function PitchCard({
         >
           <Link href={link.url} passHref>
             {link.button ? (
-              <Button
-                mb="2rem"
-                as="a"
-                {...(link.target && { target: link.target, rel: "noopener" })}
-              >
+              <Button mb="2rem" as="a" {...getTargetProps(link.target)}>
                 {link.text}
               </Button>
             ) : (
-              <Text
-                as="a"
-                {...(link.target && { target: link.target, rel: "noopener" })}
-                color="blue_700"
-              >
+              <Text as="a" {...getTargetProps(link.target)} color="blue_700">
                 {link.text}
               </Text>
             )}

--- a/src/components/organisms/NavBar/index.js
+++ b/src/components/organisms/NavBar/index.js
@@ -2,6 +2,7 @@ import React, { useMemo } from "react"
 import { Box, Container, Flex } from "@rent_avail/layout"
 import { Button } from "@rent_avail/controls"
 import styled, { createGlobalStyle } from "styled-components"
+import { getTargetProps } from "utils/link"
 
 const GlobalStyle = createGlobalStyle`
   :root {
@@ -76,30 +77,25 @@ export default function NavBar({
               overflow: "hidden",
             }}
           >
-            {defaultLinks.map(({ href, text, target }) => {
-              return (
-                <NavBarButton
-                  key={href}
-                  href={href}
-                  {...(target && { target, rel: "noopener" })}
-                  forwardedAs="a"
-                  ml="2rem"
-                  display={primaryLink ? ["none", "none", "block"] : "block"}
-                  flex="none"
-                >
-                  {text}
-                </NavBarButton>
-              )
-            })}
+            {defaultLinks.map(({ href, text, target }) => (
+              <NavBarButton
+                key={href}
+                href={href}
+                {...getTargetProps(target)}
+                forwardedAs="a"
+                ml="2rem"
+                display={primaryLink ? ["none", "none", "block"] : "block"}
+                flex="none"
+              >
+                {text}
+              </NavBarButton>
+            ))}
           </Flex>
           {primaryLink && (
             <NavBarButton
               variant="primary"
               href={primaryLink.href}
-              {...(primaryLink.target && {
-                target: primaryLink.target,
-                rel: "noopener",
-              })}
+              {...getTargetProps(primaryLink.target)}
               forwardedAs="a"
               flex="0 0 auto"
               ml="2rem"

--- a/src/components/organisms/NavBar/index.js
+++ b/src/components/organisms/NavBar/index.js
@@ -76,17 +76,18 @@ export default function NavBar({
               overflow: "hidden",
             }}
           >
-            {defaultLinks.map((link) => {
+            {defaultLinks.map(({ href, text, target }) => {
               return (
                 <NavBarButton
-                  key={link.href}
-                  href={link.href}
+                  key={href}
+                  href={href}
+                  {...(target && { target, rel: "noopener" })}
                   forwardedAs="a"
                   ml="2rem"
                   display={primaryLink ? ["none", "none", "block"] : "block"}
                   flex="none"
                 >
-                  {link.text}
+                  {text}
                 </NavBarButton>
               )
             })}
@@ -95,6 +96,10 @@ export default function NavBar({
             <NavBarButton
               variant="primary"
               href={primaryLink.href}
+              {...(primaryLink.target && {
+                target: primaryLink.target,
+                rel: "noopener",
+              })}
               forwardedAs="a"
               flex="0 0 auto"
               ml="2rem"

--- a/src/components/organisms/NavBar/index.js
+++ b/src/components/organisms/NavBar/index.js
@@ -1,7 +1,7 @@
 import React, { useMemo } from "react"
 import { Box, Container, Flex } from "@rent_avail/layout"
 import { Button } from "@rent_avail/controls"
-import styled, { createGlobalStyle, useTheme } from "styled-components"
+import styled, { createGlobalStyle } from "styled-components"
 
 const GlobalStyle = createGlobalStyle`
   :root {
@@ -14,23 +14,20 @@ const NavBarButton = styled(Button)`
   height: 48px;
 `
 
-const NavBar = ({
+export default function NavBar({
   background = "ui_100",
   links = [],
   containerWidth = "96rem",
   sticky,
   ...props
-}) => {
-  const { breakpoints } = useTheme()
-  const [linksSorted, splitIndex] = useMemo(() => {
-    const sorted = links.sort(({ push: a }, { push: b }) => {
-      if (a === b) {
-        return 0
-      }
-      return a ? 1 : -1
-    })
-    return [sorted, sorted.findIndex(({ push }) => push)]
+}) {
+  const [defaultLinks, primaryLink] = useMemo(() => {
+    const dLinks = [...links]
+    const pLinkIndex = dLinks.findIndex(({ primary }) => primary)
+    const [pLink] = pLinkIndex !== -1 ? dLinks.splice(pLinkIndex, 1) : []
+    return [dLinks, pLink]
   }, [links])
+
   return (
     <Box
       bg={background}
@@ -49,12 +46,12 @@ const NavBar = ({
           <Box
             as="a"
             href="https://avail.co"
-            mr="2rem"
-            width={["48px", "auto"]}
-            height="48px"
             sx={{
               display: "block",
               overflow: "hidden",
+              width: ["48px", "auto"],
+              height: "48px",
+              flex: "0 0 auto",
             }}
           >
             <Box
@@ -67,33 +64,46 @@ const NavBar = ({
               width={195}
             />
           </Box>
-          {linksSorted.map((link, index) => {
-            const bpIndex = breakpoints.indexOf(link.breakpoint)
-            const display =
-              bpIndex !== -1
-                ? Array(bpIndex + 2)
-                    .fill("none")
-                    .fill("block", bpIndex + 1)
-                : "block"
-            return (
-              <React.Fragment key={link.href}>
-                {index === splitIndex && <Box ml="auto" key="separator" />}
+          <Flex
+            sx={{
+              flexDirection: "row",
+              justifyContent: primaryLink
+                ? "flex-start"
+                : ["flex-end", "flex-end", "flex-end", "flex-start"],
+              flex: "1 1 auto",
+              flexWrap: "wrap",
+              height: "48px",
+              overflow: "hidden",
+            }}
+          >
+            {defaultLinks.map((link) => {
+              return (
                 <NavBarButton
-                  variant={link.primary ? "primary" : "default"}
+                  key={link.href}
                   href={link.href}
                   forwardedAs="a"
-                  display={display}
-                  mr={index === links.length - 1 ? "0" : "2rem"}
+                  ml="2rem"
+                  display={primaryLink ? ["none", "none", "block"] : "block"}
+                  flex="none"
                 >
                   {link.text}
                 </NavBarButton>
-              </React.Fragment>
-            )
-          })}
+              )
+            })}
+          </Flex>
+          {primaryLink && (
+            <NavBarButton
+              variant="primary"
+              href={primaryLink.href}
+              forwardedAs="a"
+              flex="0 0 auto"
+              ml="2rem"
+            >
+              {primaryLink.text}
+            </NavBarButton>
+          )}
         </Flex>
       </Container>
     </Box>
   )
 }
-
-export default NavBar

--- a/src/components/organisms/NavBar/index.js
+++ b/src/components/organisms/NavBar/index.js
@@ -12,9 +12,26 @@ const GlobalStyle = createGlobalStyle`
 
 const NavBarButton = styled(Button)`
   border: none;
-  height: 48px;
+  height: 4rem;
 `
 
+/**
+ * @typedef Link
+ * @type {object}
+ * @property {string} href - a Link href
+ * @property {string | undefined} target - Link target property
+ * @property {boolean | undefined} push - specifies if button should be pushed to the right
+ * @property {boolean | undefined} primary - indicates primary button. NB: Only one primary button is supported
+ */
+
+/**
+ * @param background - a background color in the theme format, e.g. - "ui_100" for white
+ * @param links - a collection of objects of @type Link
+ * @param containerWidth - width in space units to limit Nav Bar width
+ * @param sticky - boolean to indicate if NavBar should be sticky. If true - will inject "scroll-padding-top" as global style
+ * @param props - rest of the props
+ * @returns {JSX.Element}
+ */
 export default function NavBar({
   background = "ui_100",
   links = [],
@@ -22,12 +39,42 @@ export default function NavBar({
   sticky,
   ...props
 }) {
-  const [defaultLinks, primaryLink] = useMemo(() => {
-    const dLinks = [...links]
-    const pLinkIndex = dLinks.findIndex(({ primary }) => primary)
-    const [pLink] = pLinkIndex !== -1 ? dLinks.splice(pLinkIndex, 1) : []
-    return [dLinks, pLink]
+  const [defaultLinks, primaryLink, pushIndex] = useMemo(() => {
+    /** Clone links, since we are going to perform some dirty mutations */
+    const _defaultLinks = [...links]
+
+    /** Find and remove the primary link from the default links using mutating .splice.
+     * NB: Only the first link with { primary: true } would be treated as such, -
+     * the rest would be considered default links */
+    const primaryLinkIndex = _defaultLinks.findIndex(({ primary }) => primary)
+    const [_primaryLink] =
+      primaryLinkIndex !== -1 ? _defaultLinks.splice(primaryLinkIndex, 1) : []
+
+    /** Check if links contain { push: true }. If so, - we will render the default links as "row-reverse",
+     * because the expectation would be that links with { push: true } disappear last on smaller devices.
+     * To achieve that, we will sort the links so that the ones with { push: true } are at the head of the array
+     * and then reverse the array. We will also recalculate "pushIndex" as the last index in this case,
+     * in order to inject "margin-left: auto" at the correct link */
+    let _pushIndex = _defaultLinks.findIndex(({ push }) => push)
+    if (_pushIndex !== -1) {
+      _defaultLinks.sort(({ push: a }, { push: b }) => {
+        if (a === b) return 0
+        return a ? 1 : -1
+      })
+
+      _defaultLinks.reverse()
+
+      _pushIndex = _defaultLinks.reduce(
+        (r, { push }, idx) => (push ? idx : r),
+        -1
+      )
+    }
+
+    return [_defaultLinks, _primaryLink, _pushIndex]
   }, [links])
+
+  const hasPrimary = !!primaryLink
+  const hasPush = pushIndex !== -1
 
   return (
     <Box
@@ -50,9 +97,10 @@ export default function NavBar({
             sx={{
               display: "block",
               overflow: "hidden",
-              width: ["48px", "auto"],
-              height: "48px",
+              width: ["4rem", "4rem", "auto"],
+              height: "4rem",
               flex: "0 0 auto",
+              mr: "2rem",
             }}
           >
             <Box
@@ -67,31 +115,32 @@ export default function NavBar({
           </Box>
           <Flex
             sx={{
-              flexDirection: "row",
-              justifyContent: primaryLink
-                ? "flex-start"
+              visibility: hasPrimary ? ["hidden", "visible"] : "visible",
+              flexDirection: hasPush ? "row-reverse" : "row",
+              justifyContent: hasPush
+                ? ["flex-start", "flex-start", "flex-start", "flex-end"]
                 : ["flex-end", "flex-end", "flex-end", "flex-start"],
               flex: "1 1 auto",
               flexWrap: "wrap",
-              height: "48px",
+              height: "4rem",
               overflow: "hidden",
+              gap: "2rem",
             }}
           >
-            {defaultLinks.map(({ href, text, target }) => (
+            {defaultLinks.map(({ href, text, target }, idx) => (
               <NavBarButton
                 key={href}
                 href={href}
                 {...getTargetProps(target)}
                 forwardedAs="a"
-                ml="2rem"
-                display={primaryLink ? ["none", "none", "block"] : "block"}
                 flex="none"
+                ml={idx === pushIndex ? "auto" : 0}
               >
                 {text}
               </NavBarButton>
             ))}
           </Flex>
-          {primaryLink && (
+          {hasPrimary && (
             <NavBarButton
               variant="primary"
               href={primaryLink.href}

--- a/src/components/organisms/NavBar/nav-bar.stories.js
+++ b/src/components/organisms/NavBar/nav-bar.stories.js
@@ -9,10 +9,10 @@ export default {
 
 export function Default() {
   const links = [
-    { text: "Overview", href: "#overview", breakpoint: "960px" },
-    { text: "Features", href: "#features", breakpoint: "960px" },
-    { text: "Use cases", href: "#use-cases", breakpoint: "1200px" },
-    { text: "Pricing", href: "#pricing", push: true, breakpoint: "720px" },
+    { text: "Overview", href: "#overview" },
+    { text: "Features", href: "#features" },
+    { text: "Use cases", href: "#use-cases" },
+    { text: "Pricing", href: "#pricing" },
     {
       text: "Try For Free",
       href: "https://www.avail.co/users/new",

--- a/src/components/organisms/NavBar/nav-bar.stories.js
+++ b/src/components/organisms/NavBar/nav-bar.stories.js
@@ -17,7 +17,7 @@ export function Default() {
       text: "Try For Free",
       href: "https://www.avail.co/users/new",
       primary: true,
-      push: true,
+      target: "_blank",
     },
   ]
   return (

--- a/src/components/organisms/NavBar/nav-bar.stories.js
+++ b/src/components/organisms/NavBar/nav-bar.stories.js
@@ -10,14 +10,15 @@ export default {
 export function Default() {
   const links = [
     { text: "Overview", href: "#overview" },
+    { text: "Pricing", href: "#pricing", push: true },
+    { text: "Icing", href: "#icing", push: true },
     { text: "Features", href: "#features" },
-    { text: "Use cases", href: "#use-cases" },
-    { text: "Pricing", href: "#pricing" },
     {
       text: "Try For Free",
       href: "https://www.avail.co/users/new",
       primary: true,
       target: "_blank",
+      push: true,
     },
   ]
   return (

--- a/src/components/partials/SliceZone/components/Link/index.js
+++ b/src/components/partials/SliceZone/components/Link/index.js
@@ -1,6 +1,7 @@
 import React from "react"
 import NextLink from "next/link"
 import { useUrlResolver } from "components/partials/UrlResolver"
+import { getTargetProps } from "utils/link"
 
 const LinkType = {
   Web: "Web",
@@ -39,7 +40,7 @@ const Link = ({ link, children, ...props }) => {
   return (
     <NextLink passHref href={href} {...props}>
       {React.cloneElement(children, {
-        ...(target && { target, rel: "noopener" }),
+        ...getTargetProps(target),
       })}
     </NextLink>
   )

--- a/src/components/partials/SliceZone/components/RichText/html-serializer.js
+++ b/src/components/partials/SliceZone/components/RichText/html-serializer.js
@@ -9,6 +9,7 @@ import {
 } from "components/partials/SliceZone/components/RichText/components/List"
 import { H1_SIZING, H2_SIZING, H3_SIZING } from "config"
 import { useUrlResolver } from "components/partials/UrlResolver"
+import { getTargetProps } from "utils/link"
 
 const createHeading = (as, props, children) => {
   return children && children[0] ? (
@@ -67,17 +68,12 @@ const htmlSerializer = (props) => {
       case Elements.oList:
         return React.createElement(OList, { ...props, key }, children)
       case Elements.hyperlink: {
-        const targetAttr = element.data.target
-          ? { target: element.data.target }
-          : {}
-        const relAttr = element.data.target ? { rel: "noopener" } : {}
         return React.createElement(
           "a",
           {
             href: urlResolver(element.data.url) || linkResolver(element.data),
             className: "link",
-            ...targetAttr,
-            ...relAttr,
+            ...getTargetProps(element.data.target),
             ...props,
             key,
           },

--- a/src/utils/link.js
+++ b/src/utils/link.js
@@ -1,0 +1,5 @@
+export function getTargetProps(target) {
+  if (target) {
+    return { target, ...(target !== "_self" && { rel: "noopener" }) }
+  }
+}


### PR DESCRIPTION
This PR simplifies NavBar in the following ways:

- Removes `breakpoint` options
- Facilitates "automatic" responsiveness

Introduces the following limitations:

- Only one primary button can exist - the first button with `primary: true`
- Priority of buttons for responsiveness is simply controlled by their order and behaves differently when there are "pushed" buttons present
    - With no pushed buttons, - the order is conventional - the first button will be hidden last
    - With pushed buttons present, - the order is reversed - the last (pushed) buttons will be hidden last

"Automatic" responsiveness is based on `flex-wrap` and `overflow: hidden`, where buttons wrap out of view when they no longer fit in the box.