### PR TITLE
Add Prismic labels support for RichText, set default heading sizing for components

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,7 @@
 {
   "extends": ["airbnb", "prettier", "prettier/react"],
   "plugins": ["prettier"],
-  "parser": "babel-eslint",
+  "parser": "@babel/eslint-parser",
   "env": {
     "es6": true,
     "browser": true,

--- a/package.json
+++ b/package.json
@@ -40,11 +40,11 @@
   },
   "devDependencies": {
     "@babel/core": "^7.12.10",
+    "@babel/eslint-parser": "^7.12.1",
     "@storybook/addon-actions": "^6.1.11",
     "@storybook/addon-essentials": "^6.1.11",
     "@storybook/addon-links": "^6.1.11",
     "@storybook/react": "^6.1.11",
-    "babel-eslint": "^10.1.0",
     "babel-loader": "^8.2.2",
     "babel-plugin-module-resolver": "^4.1.0",
     "babel-plugin-styled-components": "^1.12.0",

--- a/pages/_app.js
+++ b/pages/_app.js
@@ -2,7 +2,6 @@ import React from "react"
 import { createGlobalStyle, ThemeProvider } from "styled-components"
 import { theme, Base as Reset } from "@rent_avail/base"
 import PreviewWarning from "components/partials/PreviewWarning"
-import { RichTextGlobalStyle } from "components/partials/SliceZone/components/RichText"
 import { DefaultSeo } from "next-seo"
 import { BREAKPOINTS, DEFAULT_SEO } from "config"
 import { UIDReset } from "react-uid"
@@ -23,7 +22,6 @@ export default function App({ Component, pageProps }) {
       <DefaultSeo {...DEFAULT_SEO} />
       <Reset />
       <GlobalStyles />
-      <RichTextGlobalStyle />
       {preview && <PreviewWarning />}
       <UIDReset prefix="uid_">
         <Component {...pageProps} />

--- a/src/components/molecules/PitchCard/index.js
+++ b/src/components/molecules/PitchCard/index.js
@@ -4,9 +4,10 @@ import { Button } from "@rent_avail/controls"
 import { Text } from "@rent_avail/typography"
 import * as React from "react"
 import { getTargetProps } from "utils/link"
-import { Typography } from "config"
+import { STYLING } from "config"
 
 export function PitchCard({ title, description, icon = null, link, ...props }) {
+  const isButtonVariant = !!link?.button
   return (
     <Col {...props} display="flex" flexDirection="column">
       {icon?.url && (
@@ -21,21 +22,21 @@ export function PitchCard({ title, description, icon = null, link, ...props }) {
       {title &&
         React.cloneElement(title, {
           sx: {
-            ...(link?.button ? Typography.H3 : Typography.H5),
+            ...(isButtonVariant ? STYLING.title : STYLING.body__emphasis),
             ...title.props?.sx,
-            marginBottom: link?.button ? "2rem" : "1rem",
+            marginBottom: isButtonVariant ? "2rem" : "1rem",
           },
         })}
       {description && (
-        <Box flex={link?.button ? "1 1 auto" : "initial"}>{description}</Box>
+        <Box flex={isButtonVariant ? "1 1 auto" : "initial"}>{description}</Box>
       )}
       {link && (
         <Flex
-          mt={link.button ? "3rem" : "1.5rem"}
-          justifyContent={link.button ? "center" : "flex-start"}
+          mt={isButtonVariant ? "3rem" : "1.5rem"}
+          justifyContent={isButtonVariant ? "center" : "flex-start"}
         >
           <Link href={link.url} passHref>
-            {link.button ? (
+            {isButtonVariant ? (
               <Button as="a" {...getTargetProps(link.target)}>
                 {link.text}
               </Button>

--- a/src/components/molecules/PitchCard/index.js
+++ b/src/components/molecules/PitchCard/index.js
@@ -4,17 +4,12 @@ import { Button } from "@rent_avail/controls"
 import { Text } from "@rent_avail/typography"
 import * as React from "react"
 import { getTargetProps } from "utils/link"
+import { Typography } from "config"
 
-export function PitchCard({
-  title = "",
-  description = "",
-  icon = null,
-  link,
-  ...props
-}) {
+export function PitchCard({ title, description, icon = null, link, ...props }) {
   return (
     <Col {...props} display="flex" flexDirection="column">
-      {icon && icon.url && (
+      {icon?.url && (
         <Box
           as="img"
           src={icon.url}
@@ -23,20 +18,25 @@ export function PitchCard({
           width="10rem"
         />
       )}
-      {title && <Box mb="2rem">{title}</Box>}
+      {title &&
+        React.cloneElement(title, {
+          sx: {
+            ...(link?.button ? Typography.H3 : Typography.H5),
+            ...title.props?.sx,
+            marginBottom: link?.button ? "2rem" : "1rem",
+          },
+        })}
       {description && (
-        <Box flex={link && link.button ? "1 1 auto" : "initial"}>
-          {description}
-        </Box>
+        <Box flex={link?.button ? "1 1 auto" : "initial"}>{description}</Box>
       )}
       {link && (
         <Flex
-          mt="1.5rem"
+          mt={link.button ? "3rem" : "1.5rem"}
           justifyContent={link.button ? "center" : "flex-start"}
         >
           <Link href={link.url} passHref>
             {link.button ? (
-              <Button mb="2rem" as="a" {...getTargetProps(link.target)}>
+              <Button as="a" {...getTargetProps(link.target)}>
                 {link.text}
               </Button>
             ) : (

--- a/src/components/organisms/FAQ/faq.stories.js
+++ b/src/components/organisms/FAQ/faq.stories.js
@@ -1,19 +1,20 @@
-import React, { Fragment } from "react"
+import React from "react"
 import { Text } from "@rent_avail/typography"
+import { Box } from "@rent_avail/layout"
 import { FAQ } from "./index"
 
 export default { title: "Components/FAQ" }
 
 function Answer() {
   return (
-    <>
+    <React.Fragment>
       <Text>
         Lorem ipsum dolor sit amet consectetur adipisicing elit. Expedita
         possimus officiis tenetur, ex tempora repellat quibusdam, ab soluta
         neque incidunt magni earum architecto veritatis rerum optio consectetur
         adipisci minus dicta.
       </Text>
-    </>
+    </React.Fragment>
   )
 }
 
@@ -26,9 +27,14 @@ export function Default() {
   ]
   return (
     <FAQ
-      eyebrow="FAQ"
-      title="Answers to common questions"
-      description="Ab soluta neque incidunt magni earum architecto veritatis rerum optio consectetur adipisci minus dicta."
+      eyebrow={<Text>FAQ</Text>}
+      title={<Box as="h2">Answers to common questions</Box>}
+      description={
+        <Text>
+          Ab soluta neque incidunt magni earum architecto veritatis rerum optio
+          consectetur adipisci minus dicta.
+        </Text>
+      }
       questions={questions}
       py="4rem"
     />

--- a/src/components/organisms/FAQ/index.js
+++ b/src/components/organisms/FAQ/index.js
@@ -1,37 +1,46 @@
 import * as React from "react"
 import styled from "styled-components"
 import { Box, Container, Stack } from "@rent_avail/layout"
-import { Text, Heading } from "@rent_avail/typography"
+import { Text } from "@rent_avail/typography"
 import { motion, AnimatePresence } from "framer-motion"
+import { Typography } from "config"
 
-const Accordian = styled(Box)`
+const Accordion = styled(Box)`
   cursor: pointer;
   &:hover {
     opacity: 0.75;
   }
 `
 
-function FAQ({ questions, eyebrow, title, description, ...props }) {
+function FAQ({
+  questions,
+  eyebrow,
+  title,
+  description,
+  color,
+  containerWidth,
+  ...props
+}) {
   const [openIdx, setOpen] = React.useState(null)
   return (
-    <Box {...props}>
-      <Container>
-        {eyebrow && (
-          <Text color={props.color || "blue_300"} mb="1rem">
-            {eyebrow}
-          </Text>
-        )}
-        {title && (
-          <Heading as="h3" mb="1rem">
-            {title}
-          </Heading>
-        )}
+    <Box color={color} {...props}>
+      <Container {...(containerWidth && { maxWidth: containerWidth })}>
+        {eyebrow &&
+          React.cloneElement(eyebrow, {
+            color: color || "blue_300",
+            mb: "1rem",
+          })}
+        {title &&
+          React.cloneElement(title, {
+            mb: "1rem",
+            sx: { ...Typography.H2, ...title.props?.sx },
+          })}
         {description && <Box mb="2rem">{description}</Box>}
         <Stack>
           {questions.map(({ question, answer: Answer }, idx) => {
             const isOpen = idx === openIdx
             return (
-              <Accordian
+              <Accordion
                 borderRadius="0.25rem"
                 p="2rem"
                 bg="blue_100"
@@ -56,7 +65,7 @@ function FAQ({ questions, eyebrow, title, description, ...props }) {
                     </Box>
                   )}
                 </AnimatePresence>
-              </Accordian>
+              </Accordion>
             )
           })}
         </Stack>

--- a/src/components/organisms/FAQ/index.js
+++ b/src/components/organisms/FAQ/index.js
@@ -3,7 +3,7 @@ import styled from "styled-components"
 import { Box, Container, Stack } from "@rent_avail/layout"
 import { Text } from "@rent_avail/typography"
 import { motion, AnimatePresence } from "framer-motion"
-import { Typography } from "config"
+import { STYLING } from "config"
 
 const Accordion = styled(Box)`
   cursor: pointer;
@@ -33,7 +33,7 @@ function FAQ({
         {title &&
           React.cloneElement(title, {
             mb: "1rem",
-            sx: { ...Typography.H2, ...title.props?.sx },
+            sx: { ...STYLING.headline, ...title.props?.sx },
           })}
         {description && <Box mb="2rem">{description}</Box>}
         <Stack>

--- a/src/components/organisms/Hero/hero.stories.js
+++ b/src/components/organisms/Hero/hero.stories.js
@@ -1,7 +1,8 @@
 import React from "react"
-import { Heading, Text } from "@rent_avail/typography"
+import { Text } from "@rent_avail/typography"
 import { Button } from "@rent_avail/controls"
 import Link from "next/link"
+import { Box } from "@rent_avail/layout"
 import { Hero } from "./index"
 
 export default { title: "Components/Hero" }
@@ -9,7 +10,7 @@ export default { title: "Components/Hero" }
 export function Default() {
   return (
     <Hero
-      title={<Heading as="h1">Hero Title</Heading>}
+      title={<Box as="h1">Hero Title</Box>}
       description={
         <Text>
           Lorem ipsum dolor sit amet consectetur adipisicing elit. Dolores vel
@@ -31,9 +32,7 @@ export function WithIllustration() {
         alt: "",
       }}
       title={
-        <Heading as="h1">
-          Feel good about the way you manage your rentals.
-        </Heading>
+        <Box as="h1">Feel good about the way you manage your rentals.</Box>
       }
       description={
         <Text>
@@ -50,9 +49,9 @@ export function WithBgColor() {
     <Hero
       skew="left"
       title={
-        <Heading as="h1">
+        <Box as="h1">
           Publish your listing to over a dozen top rental sites all at once.
-        </Heading>
+        </Box>
       }
       description={
         <Text>
@@ -86,9 +85,7 @@ export function WithSwap() {
       }}
       imagePosition="left"
       title={
-        <Heading as="h1">
-          Feel good about the way you manage your rentals.
-        </Heading>
+        <Box as="h1">Feel good about the way you manage your rentals.</Box>
       }
       description={
         <Text>

--- a/src/components/organisms/Hero/index.js
+++ b/src/components/organisms/Hero/index.js
@@ -1,7 +1,7 @@
 import React, { cloneElement } from "react"
 import styled from "styled-components"
 import { Container, Box, Grid, Col, Stack } from "@rent_avail/layout"
-import { Typography } from "config"
+import { STYLING } from "config"
 
 const HeroWrapper = styled(Box)`
   position: relative;
@@ -48,7 +48,7 @@ function Hero({
         <Col span={image ? [12, 12, 12, 6] : [12]}>
           {cloneElement(title, {
             sx: {
-              ...(image ? Typography.H2 : Typography.H1),
+              ...(image ? STYLING.headline : STYLING.hero),
               fontWeight: ["regular", "light"],
               ...title.props?.sx,
             },

--- a/src/components/organisms/Hero/index.js
+++ b/src/components/organisms/Hero/index.js
@@ -1,6 +1,7 @@
 import React, { cloneElement } from "react"
-import styled, { useTheme } from "styled-components"
+import styled from "styled-components"
 import { Container, Box, Grid, Col, Stack } from "@rent_avail/layout"
+import { Typography } from "config"
 
 const HeroWrapper = styled(Box)`
   position: relative;
@@ -33,7 +34,6 @@ function Hero({
   children,
   ...props
 }) {
-  const { fontWeights, fontSizes } = useTheme()
   const links = primaryLink || secondaryLink
   return (
     <HeroWrapper {...props} skewBg={bg} skew={skew} pt="4rem" pb="10rem">
@@ -47,10 +47,11 @@ function Hero({
       >
         <Col span={image ? [12, 12, 12, 6] : [12]}>
           {cloneElement(title, {
-            fontSize: image
-              ? [fontSizes.subtitle, fontSizes.title, fontSizes.headline]
-              : [fontSizes.title, fontSizes.headline, fontSizes.hero],
-            fontWeight: [fontWeights.regular, fontWeights.light],
+            sx: {
+              ...(image ? Typography.H2 : Typography.H1),
+              fontWeight: ["regular", "light"],
+              ...title.props?.sx,
+            },
           })}
           <Box mt="2rem">{description}</Box>
           {links && (

--- a/src/components/organisms/HowItWorks/index.js
+++ b/src/components/organisms/HowItWorks/index.js
@@ -1,7 +1,7 @@
 import * as React from "react"
 import { Box, Container, Grid, Col } from "@rent_avail/layout"
 import { Text } from "@rent_avail/typography"
-import { Typography } from "config"
+import { STYLING } from "config"
 
 function HowItWorks({
   title,
@@ -22,7 +22,7 @@ function HowItWorks({
         {title &&
           React.cloneElement(title, {
             mb: "4rem",
-            sx: { ...Typography.H2, ...title.props?.sx },
+            sx: { ...STYLING.headline, ...title.props?.sx },
           })}
         {sections.map((section, idx) => (
           <HowItWorksSection

--- a/src/components/organisms/HowItWorks/index.js
+++ b/src/components/organisms/HowItWorks/index.js
@@ -1,6 +1,7 @@
 import * as React from "react"
 import { Box, Container, Grid, Col } from "@rent_avail/layout"
 import { Text } from "@rent_avail/typography"
+import { Typography } from "config"
 
 function HowItWorks({
   title,
@@ -18,7 +19,11 @@ function HowItWorks({
             {eyebrow}
           </Text>
         )}
-        {title && React.cloneElement(title, { mb: "4rem" })}
+        {title &&
+          React.cloneElement(title, {
+            mb: "4rem",
+            sx: { ...Typography.H2, ...title.props?.sx },
+          })}
         {sections.map((section, idx) => (
           <HowItWorksSection
             {...section}

--- a/src/components/organisms/PitchCards/index.js
+++ b/src/components/organisms/PitchCards/index.js
@@ -2,7 +2,7 @@ import * as React from "react"
 import { Col, Container, Grid } from "@rent_avail/layout"
 import { Text } from "@rent_avail/typography"
 import { PitchCard } from "components/molecules/PitchCard"
-import { Typography } from "config"
+import { STYLING } from "config"
 
 function PitchCards({ span, sections, title, description, eyebrow, ...props }) {
   const cardSpan =
@@ -19,7 +19,7 @@ function PitchCards({ span, sections, title, description, eyebrow, ...props }) {
           )}
           {title &&
             React.cloneElement(title, {
-              sx: { ...Typography.H2, ...title.props?.sx },
+              sx: { ...STYLING.headline, ...title.props?.sx },
             })}
           {description && description}
         </Col>

--- a/src/components/organisms/PitchCards/index.js
+++ b/src/components/organisms/PitchCards/index.js
@@ -2,6 +2,7 @@ import * as React from "react"
 import { Col, Container, Grid } from "@rent_avail/layout"
 import { Text } from "@rent_avail/typography"
 import { PitchCard } from "components/molecules/PitchCard"
+import { Typography } from "config"
 
 function PitchCards({ span, sections, title, description, eyebrow, ...props }) {
   const cardSpan =
@@ -16,7 +17,10 @@ function PitchCards({ span, sections, title, description, eyebrow, ...props }) {
               {eyebrow}
             </Text>
           )}
-          {title && title}
+          {title &&
+            React.cloneElement(title, {
+              sx: { ...Typography.H2, ...title.props?.sx },
+            })}
           {description && description}
         </Col>
       )}

--- a/src/components/organisms/PitchCards/pitch-cards.stories.js
+++ b/src/components/organisms/PitchCards/pitch-cards.stories.js
@@ -1,5 +1,5 @@
 import React from "react"
-import { Heading } from "@rent_avail/typography"
+import { Box } from "@rent_avail/layout"
 import { PitchCards } from "./index"
 
 export default { title: "Components/Pitch Cards" }
@@ -28,7 +28,7 @@ const sectionData = [
 ]
 
 const sections = sectionData.map(({ title, description }) => ({
-  title: <Heading as="h5">{title}</Heading>,
+  title: <Box as="h3">{title}</Box>,
   description,
 }))
 
@@ -70,9 +70,9 @@ const linkSections = iconSections.map((section, idx) => ({
 
 const buttonLinkSections = sectionData.map(({ title, description }, idx) => ({
   title: (
-    <Heading as="h3" textAlign="center">
+    <Box as="h3" textAlign="center">
       {title}
-    </Heading>
+    </Box>
   ),
   description,
   link: { ...links[idx], text: "View sample", button: true },
@@ -84,9 +84,9 @@ export function Default() {
       sections={sections}
       eyebrow="Eyebrow"
       title={
-        <Heading as="h2" mb="1rem">
+        <Box as="h2" mb="1rem">
           Let Me Pitch You
-        </Heading>
+        </Box>
       }
       description="A pre-designed piece of content perfect for showcasing the top features of a product or service. It's more condensed than the how-it-works section."
       mt="4rem"
@@ -100,9 +100,9 @@ export function WithIcons() {
       sections={iconSections}
       eyebrow="Eyebrow"
       title={
-        <Heading as="h2" mb="1rem">
+        <Box as="h2" mb="1rem">
           Let Me Pitch You
-        </Heading>
+        </Box>
       }
       description="A pre-designed piece of content perfect for showcasing the top features of a product or service. It's more condensed than the how-it-works section."
       mt="4rem"
@@ -116,9 +116,9 @@ export function WithThreeSections() {
       sections={iconSections.slice(0, 3)}
       eyebrow="Eyebrow"
       title={
-        <Heading as="h2" mb="1rem">
+        <Box as="h2" mb="1rem">
           Let Me Pitch You
-        </Heading>
+        </Box>
       }
       description="A pre-designed piece of content perfect for showcasing the top features of a product or service. It's more condensed than the how-it-works section."
       mt="4rem"
@@ -132,9 +132,9 @@ export function WithTwoSections() {
       sections={iconSections.slice(0, 2)}
       eyebrow="Eyebrow"
       title={
-        <Heading as="h2" mb="1rem">
+        <Box as="h2" mb="1rem">
           Let Me Pitch You
-        </Heading>
+        </Box>
       }
       description="A pre-designed piece of content perfect for showcasing the top features of a product or service. It's more condensed than the how-it-works section."
       mt="4rem"
@@ -148,9 +148,9 @@ export function WithLinks() {
       sections={linkSections}
       eyebrow="Eyebrow"
       title={
-        <Heading as="h2" mb="1rem">
+        <Box as="h2" mb="1rem">
           Let Me Pitch You
-        </Heading>
+        </Box>
       }
       description="A pre-designed piece of content perfect for showcasing the top features of a product or service. It's more condensed than the how-it-works section."
       mt="4rem"
@@ -164,9 +164,9 @@ export function WithButtonLinks() {
       sections={buttonLinkSections.slice(0, 3)}
       eyebrow="Eyebrow"
       title={
-        <Heading as="h2" mb="1rem">
+        <Box as="h2" mb="1rem">
           Let Me Pitch You
-        </Heading>
+        </Box>
       }
       description="A pre-designed piece of content perfect for showcasing the top features of a product or service. It's more condensed than the how-it-works section."
       mt="4rem"

--- a/src/components/partials/SliceZone/components/EmailCaptureSlice/index.js
+++ b/src/components/partials/SliceZone/components/EmailCaptureSlice/index.js
@@ -3,7 +3,7 @@ import { Container } from "@rent_avail/layout"
 import EmailCapture from "components/molecules/EmailCapture"
 import RichText from "components/partials/SliceZone/components/RichText"
 import Anchor from "components/elements/Anchor"
-import { CONTAINER_WIDTHS, Typography } from "config"
+import { CONTAINER_WIDTHS, STYLING } from "config"
 import { useUrlResolver } from "components/partials/UrlResolver"
 import { useUID } from "react-uid"
 
@@ -22,7 +22,7 @@ const EmailCaptureSlice = ({ slice }) => {
           textAlign={["left", "center"]}
           color="blue_500"
           render={title}
-          sx={{ ...Typography.H3 }}
+          sx={{ ...STYLING.title }}
         />
         <EmailCapture
           inputLabel={label}

--- a/src/components/partials/SliceZone/components/EmailCaptureSlice/index.js
+++ b/src/components/partials/SliceZone/components/EmailCaptureSlice/index.js
@@ -3,7 +3,7 @@ import { Container } from "@rent_avail/layout"
 import EmailCapture from "components/molecules/EmailCapture"
 import RichText from "components/partials/SliceZone/components/RichText"
 import Anchor from "components/elements/Anchor"
-import { CONTAINER_WIDTHS, H3_SIZING } from "config"
+import { CONTAINER_WIDTHS, Typography } from "config"
 import { useUrlResolver } from "components/partials/UrlResolver"
 import { useUID } from "react-uid"
 
@@ -22,8 +22,7 @@ const EmailCaptureSlice = ({ slice }) => {
           textAlign={["left", "center"]}
           color="blue_500"
           render={title}
-          heading
-          {...H3_SIZING}
+          sx={{ ...Typography.H3 }}
         />
         <EmailCapture
           inputLabel={label}

--- a/src/components/partials/SliceZone/components/FrequentlyAskedQuestionsSlice/index.js
+++ b/src/components/partials/SliceZone/components/FrequentlyAskedQuestionsSlice/index.js
@@ -3,15 +3,9 @@ import { FAQ } from "components/organisms/FAQ"
 import { CONTAINER_WIDTHS } from "config"
 import RichText from "../RichText"
 
-const FrequentlyAskedQuestionsSlice = ({ slice }) => {
+export default function FrequentlyAskedQuestionsSlice({ slice }) {
   const {
-    primary: {
-      background,
-      color,
-      title,
-      description,
-      eyebrow,
-    },
+    primary: { background, color, title, description, eyebrow },
   } = slice
 
   const questions = slice.items.map(({ question, answer }) => ({
@@ -21,15 +15,14 @@ const FrequentlyAskedQuestionsSlice = ({ slice }) => {
 
   return (
     <FAQ
-      title={<RichText render={title} heading />}
-      description={<RichText render={description} />}
-      eyebrow={<RichText render={eyebrow} />}
+      title={title[0]?.text && <RichText render={title} />}
+      description={description[0]?.text && <RichText render={description} />}
+      eyebrow={eyebrow[0]?.text && <RichText render={eyebrow} />}
       questions={questions}
       containerWidth={CONTAINER_WIDTHS}
       bg={background}
       color={color}
+      py="6rem"
     />
   )
 }
-
-export default FrequentlyAskedQuestionsSlice

--- a/src/components/partials/SliceZone/components/FrequentlyAskedQuestionsSlice/index.js
+++ b/src/components/partials/SliceZone/components/FrequentlyAskedQuestionsSlice/index.js
@@ -15,9 +15,9 @@ export default function FrequentlyAskedQuestionsSlice({ slice }) {
 
   return (
     <FAQ
-      title={title[0]?.text && <RichText render={title} />}
-      description={description[0]?.text && <RichText render={description} />}
-      eyebrow={eyebrow[0]?.text && <RichText render={eyebrow} />}
+      title={title?.[0]?.text && <RichText render={title} />}
+      description={description?.[0]?.text && <RichText render={description} />}
+      eyebrow={eyebrow?.[0]?.text && <RichText render={eyebrow} />}
       questions={questions}
       containerWidth={CONTAINER_WIDTHS}
       bg={background}

--- a/src/components/partials/SliceZone/components/HeroSlice/index.js
+++ b/src/components/partials/SliceZone/components/HeroSlice/index.js
@@ -30,7 +30,7 @@ const HeroSlice = ({ slice }) => {
 
   return (
     <Hero
-      title={<RichText render={title} heading />}
+      title={<RichText render={title} />}
       description={<RichText render={description} />}
       bg={background}
       skew={skew}

--- a/src/components/partials/SliceZone/components/HeroWithEmailCaptureSlice/index.js
+++ b/src/components/partials/SliceZone/components/HeroWithEmailCaptureSlice/index.js
@@ -30,7 +30,7 @@ const HeroWithEmailCaptureSlice = ({ slice }) => {
 
   return (
     <Hero
-      title={<RichText render={title} heading />}
+      title={<RichText render={title} />}
       description={<RichText render={description} />}
       bg={background}
       skew={skew}

--- a/src/components/partials/SliceZone/components/HowItWorksSlice/index.js
+++ b/src/components/partials/SliceZone/components/HowItWorksSlice/index.js
@@ -1,7 +1,7 @@
 import React from "react"
 import Anchor from "components/elements/Anchor"
 import { HowItWorks } from "components/organisms/HowItWorks"
-import { CONTAINER_WIDTHS, Typography } from "config"
+import { CONTAINER_WIDTHS, STYLING } from "config"
 import RichText from "../RichText"
 
 const HowItWorksSlice = ({ slice }) => {
@@ -13,7 +13,7 @@ const HowItWorksSlice = ({ slice }) => {
     uid: title?.[0]?.text || idx,
     copy: (
       <React.Fragment>
-        <RichText render={title} mb="2rem" sx={{ ...Typography.H3 }} />
+        <RichText render={title} mb="2rem" sx={{ ...STYLING.title }} />
         <RichText render={description} />
       </React.Fragment>
     ),

--- a/src/components/partials/SliceZone/components/HowItWorksSlice/index.js
+++ b/src/components/partials/SliceZone/components/HowItWorksSlice/index.js
@@ -1,7 +1,7 @@
 import React from "react"
 import Anchor from "components/elements/Anchor"
 import { HowItWorks } from "components/organisms/HowItWorks"
-import { CONTAINER_WIDTHS } from "config"
+import { CONTAINER_WIDTHS, Typography } from "config"
 import RichText from "../RichText"
 
 const HowItWorksSlice = ({ slice }) => {
@@ -10,10 +10,10 @@ const HowItWorksSlice = ({ slice }) => {
   } = slice
   // eslint-disable-next-line no-shadow
   const sections = slice.items.map(({ title, description, image }, idx) => ({
-    uid: (title && title[0] && title[0].text) || idx,
+    uid: title?.[0]?.text || idx,
     copy: (
       <React.Fragment>
-        <RichText render={title} mb="2rem" heading />
+        <RichText render={title} mb="2rem" sx={{ ...Typography.H3 }} />
         <RichText render={description} />
       </React.Fragment>
     ),
@@ -23,7 +23,7 @@ const HowItWorksSlice = ({ slice }) => {
     <React.Fragment>
       {hash && <Anchor hash={hash} />}
       <HowItWorks
-        title={<RichText render={title} heading />}
+        title={<RichText render={title} />}
         sections={sections}
         bg={background}
         containerWidth={CONTAINER_WIDTHS}

--- a/src/components/partials/SliceZone/components/PitchCardsSlice/index.js
+++ b/src/components/partials/SliceZone/components/PitchCardsSlice/index.js
@@ -25,48 +25,43 @@ const PitchCardsSlice = ({ slice }) => {
         linkAsButton,
       },
       idx
-    ) => {
-      return {
-        title: (
-          <RichText
-            textAlign={centerTitle ? "center" : "inherit"}
-            color={centerTitle ? "blue_500" : "inherit"}
-            render={title}
-            heading
-          />
-        ),
-        description: <RichText render={description} />,
-        icon,
-        key: (title && title[0] && title[0].text) || idx,
-        link:
-          linkText && linkUrl
-            ? {
-                text: linkText,
-                url: urlResolver(linkUrl.url),
-                target:
-                  linkUrl.target || (linkUrl.link_type === "Media" && "_blank"),
-                button: linkAsButton,
-              }
-            : null,
-      }
-    }
+    ) => ({
+      title: (
+        <RichText
+          textAlign={centerTitle ? "center" : "inherit"}
+          color={centerTitle ? "blue_500" : "inherit"}
+          render={title}
+        />
+      ),
+      description: <RichText render={description} />,
+      icon,
+      key: title?.[0]?.text || idx,
+      link:
+        linkText && linkUrl
+          ? {
+              text: linkText,
+              url: urlResolver(linkUrl.url),
+              target:
+                linkUrl.target || (linkUrl.link_type === "Media" && "_blank"),
+              button: linkAsButton,
+            }
+          : null,
+    })
   )
   const titleText = (
     <RichText
       color="blue_500"
       textAlign={centerTitle ? "center" : "inherit"}
       render={title}
-      heading
     />
   )
-  const titleWithImage = titleImage && titleImage.url && (
+  const titleWithImage = titleImage?.url && (
     <Box textAlign={centerTitle ? "center" : "inherit"}>
       <RichText
         display="inline-block"
         verticalAlign="bottom"
         color="blue_500"
         render={title}
-        heading
       />
       <Box
         as="img"

--- a/src/components/partials/SliceZone/components/RichText/components/Text/index.js
+++ b/src/components/partials/SliceZone/components/RichText/components/Text/index.js
@@ -1,0 +1,25 @@
+import React from "react"
+import styled from "styled-components"
+import { sx as applySx } from "@rent_avail/base"
+import { Text as _DesignSystemText } from "@rent_avail/typography"
+
+const DesignSystemText = styled(_DesignSystemText)(({ sx }) =>
+  applySx({ sx: { ...sx } })
+)
+
+export function Text({ sx, children }) {
+  return (
+    <DesignSystemText
+      sx={{
+        margin: ".5rem 0",
+        "&:empty::before": {
+          whiteSpace: "pre",
+          content: "' '",
+        },
+        ...sx,
+      }}
+    >
+      {children}
+    </DesignSystemText>
+  )
+}

--- a/src/components/partials/SliceZone/components/RichText/components/Text/index.js
+++ b/src/components/partials/SliceZone/components/RichText/components/Text/index.js
@@ -3,9 +3,9 @@ import styled from "styled-components"
 import { sx as applySx } from "@rent_avail/base"
 import { Text as _DesignSystemText } from "@rent_avail/typography"
 
-const DesignSystemText = styled(_DesignSystemText)(({ sx }) =>
-  applySx({ sx: { ...sx } })
-)
+const DesignSystemText = styled(_DesignSystemText)`
+  ${applySx};
+`
 
 export function Text({ sx, children }) {
   return (

--- a/src/components/partials/SliceZone/components/RichText/components/Text/index.js
+++ b/src/components/partials/SliceZone/components/RichText/components/Text/index.js
@@ -7,17 +7,19 @@ const DesignSystemText = styled(_DesignSystemText)`
   ${applySx};
 `
 
-export function Text({ sx, children }) {
+export function Text({ sx, children, ...props }) {
   return (
     <DesignSystemText
       sx={{
-        margin: ".5rem 0",
+        "&:not(:first-child)": { marginTop: ".5rem" },
+        "&:not(:last-child)": { marginBottom: ".5rem" },
         "&:empty::before": {
           whiteSpace: "pre",
           content: "' '",
         },
         ...sx,
       }}
+      {...props}
     >
       {children}
     </DesignSystemText>

--- a/src/components/partials/SliceZone/components/RichText/html-serializer.js
+++ b/src/components/partials/SliceZone/components/RichText/html-serializer.js
@@ -1,7 +1,7 @@
 import React from "react"
 import { Elements } from "prismic-reactjs"
 import { linkResolver } from "src/prismic.config"
-import { Typography } from "config"
+import { STYLING } from "config"
 import { useUrlResolver } from "components/partials/UrlResolver"
 import { getTargetProps } from "utils/link"
 import { Box } from "@rent_avail/layout"
@@ -18,13 +18,8 @@ function createHeading(as, { key, ...props }, children) {
   )
 }
 
-function getLabelProps(category, value) {
-  switch (category) {
-    case "Typography":
-      return Typography[value] && { sx: { ...Typography[value] } }
-    default:
-      return null
-  }
+function getLabelProps(label) {
+  return STYLING[label] && { sx: { ...STYLING[label] } }
 }
 
 export default function htmlSerializer(props) {
@@ -37,7 +32,7 @@ export default function htmlSerializer(props) {
           {
             ...props,
             sx: {
-              ...Typography.H1,
+              ...STYLING.hero,
               ...props.sx,
             },
             key,
@@ -50,7 +45,7 @@ export default function htmlSerializer(props) {
           {
             ...props,
             sx: {
-              ...Typography.H2,
+              ...STYLING.headline,
               ...props.sx,
             },
             key,
@@ -63,7 +58,7 @@ export default function htmlSerializer(props) {
           {
             ...props,
             sx: {
-              ...Typography.H3,
+              ...STYLING.title,
               ...props.sx,
             },
             key,
@@ -76,7 +71,7 @@ export default function htmlSerializer(props) {
           {
             ...props,
             sx: {
-              ...Typography.H4,
+              ...STYLING.subtitle,
               ...props.sx,
             },
             key,
@@ -89,7 +84,7 @@ export default function htmlSerializer(props) {
           {
             ...props,
             sx: {
-              ...Typography.H5,
+              ...STYLING.body__emphasis,
               ...props.sx,
             },
             key,
@@ -120,13 +115,12 @@ export default function htmlSerializer(props) {
         )
       }
       case Elements.label: {
-        if (element.data?.label?.includes(": ")) {
-          const [category, value] = element.data.label.split(": ")
+        if (element.data?.label) {
           return React.createElement(
             Text,
             {
               as: "span",
-              ...getLabelProps(category, value),
+              ...getLabelProps(element.data.label),
               key,
             },
             children

--- a/src/components/partials/SliceZone/components/RichText/html-serializer.js
+++ b/src/components/partials/SliceZone/components/RichText/html-serializer.js
@@ -1,23 +1,33 @@
 import React from "react"
 import { Elements } from "prismic-reactjs"
-import { Heading } from "@rent_avail/typography"
 import { linkResolver } from "src/prismic.config"
-import { H1_SIZING, H2_SIZING, H3_SIZING } from "config"
+import { Typography } from "config"
 import { useUrlResolver } from "components/partials/UrlResolver"
 import { getTargetProps } from "utils/link"
+import { Box } from "@rent_avail/layout"
 import { List, ListItem, OList } from "./components/List"
 import { Text } from "./components/Text"
 
-const createHeading = (as, props, children) =>
-  children && children[0] ? (
-    React.createElement(Heading, { as, ...props }, children)
+function createHeading(as, { key, ...props }, children) {
+  return children?.[0] ? (
+    React.createElement(Box, { as, key, ...props }, children)
   ) : (
     /** This a "hack", if we return NULL as we should've the RichText will
      * fall back to default implementation and will render empty heading tag */
-    <React.Fragment key={props.key} />
+    <React.Fragment key={key} />
   )
+}
 
-const htmlSerializer = (props) => {
+function getLabelProps(category, value) {
+  switch (category) {
+    case "Typography":
+      return Typography[value] && { sx: { ...Typography[value] } }
+    default:
+      return null
+  }
+}
+
+export default function htmlSerializer(props) {
   const urlResolver = useUrlResolver()
   return (type, element, content, children, key) => {
     switch (type) {
@@ -25,8 +35,11 @@ const htmlSerializer = (props) => {
         return createHeading(
           "h1",
           {
-            ...H1_SIZING,
             ...props,
+            sx: {
+              ...Typography.H1,
+              ...props.sx,
+            },
             key,
           },
           children
@@ -35,8 +48,11 @@ const htmlSerializer = (props) => {
         return createHeading(
           "h2",
           {
-            ...H2_SIZING,
             ...props,
+            sx: {
+              ...Typography.H2,
+              ...props.sx,
+            },
             key,
           },
           children
@@ -45,16 +61,41 @@ const htmlSerializer = (props) => {
         return createHeading(
           "h3",
           {
-            ...H3_SIZING,
             ...props,
+            sx: {
+              ...Typography.H3,
+              ...props.sx,
+            },
             key,
           },
           children
         )
       case Elements.heading4:
-        return createHeading("h4", { ...props, key }, children)
+        return createHeading(
+          "h4",
+          {
+            ...props,
+            sx: {
+              ...Typography.H4,
+              ...props.sx,
+            },
+            key,
+          },
+          children
+        )
       case Elements.heading5:
-        return createHeading("h5", { ...props, key }, children)
+        return createHeading(
+          "h5",
+          {
+            ...props,
+            sx: {
+              ...Typography.H5,
+              ...props.sx,
+            },
+            key,
+          },
+          children
+        )
       case Elements.heading6:
         return createHeading("h6", { ...props, key }, children)
       case Elements.paragraph:
@@ -71,17 +112,30 @@ const htmlSerializer = (props) => {
           {
             href: urlResolver(element.data.url) || linkResolver(element.data),
             className: "link",
-            ...getTargetProps(element.data.target),
             ...props,
+            ...getTargetProps(element.data.target),
             key,
           },
           children
         )
+      }
+      case Elements.label: {
+        if (element.data?.label?.includes(": ")) {
+          const [category, value] = element.data.label.split(": ")
+          return React.createElement(
+            Text,
+            {
+              as: "span",
+              ...getLabelProps(category, value),
+              key,
+            },
+            children
+          )
+        }
+        return <React.Fragment key={key}>{children}</React.Fragment>
       }
       default:
         return null
     }
   }
 }
-
-export default htmlSerializer

--- a/src/components/partials/SliceZone/components/RichText/html-serializer.js
+++ b/src/components/partials/SliceZone/components/RichText/html-serializer.js
@@ -2,24 +2,20 @@ import React from "react"
 import { Elements } from "prismic-reactjs"
 import { Heading } from "@rent_avail/typography"
 import { linkResolver } from "src/prismic.config"
-import {
-  List,
-  ListItem,
-  OList,
-} from "components/partials/SliceZone/components/RichText/components/List"
 import { H1_SIZING, H2_SIZING, H3_SIZING } from "config"
 import { useUrlResolver } from "components/partials/UrlResolver"
 import { getTargetProps } from "utils/link"
+import { List, ListItem, OList } from "./components/List"
+import { Text } from "./components/Text"
 
-const createHeading = (as, props, children) => {
-  return children && children[0] ? (
+const createHeading = (as, props, children) =>
+  children && children[0] ? (
     React.createElement(Heading, { as, ...props }, children)
   ) : (
     /** This a "hack", if we return NULL as we should've the RichText will
      * fall back to default implementation and will render empty heading tag */
     <React.Fragment key={props.key} />
   )
-}
 
 const htmlSerializer = (props) => {
   const urlResolver = useUrlResolver()
@@ -61,6 +57,8 @@ const htmlSerializer = (props) => {
         return createHeading("h5", { ...props, key }, children)
       case Elements.heading6:
         return createHeading("h6", { ...props, key }, children)
+      case Elements.paragraph:
+        return React.createElement(Text, { ...props, key }, children)
       case Elements.list:
         return React.createElement(List, { ...props, key }, children)
       case Elements.listItem:

--- a/src/components/partials/SliceZone/components/RichText/index.js
+++ b/src/components/partials/SliceZone/components/RichText/index.js
@@ -1,20 +1,9 @@
 import React from "react"
 import { RichText as PrismicRichText } from "prismic-reactjs"
 import { Box } from "@rent_avail/layout"
-import { createGlobalStyle } from "styled-components"
 import htmlSerializer from "./html-serializer"
 
-export const RichTextGlobalStyle = createGlobalStyle`
-  .rich-text p {
-    margin: .5rem 0;
-  }
-  .rich-text p:empty:before {
-    content: ' ';
-    white-space: pre;
-  }
-`
-
-const RichText = ({ render, heading, ...props }) => {
+export default function RichText({ render, heading, ...props }) {
   return heading ? (
     <PrismicRichText render={render} htmlSerializer={htmlSerializer(props)} />
   ) : (
@@ -23,5 +12,3 @@ const RichText = ({ render, heading, ...props }) => {
     </Box>
   )
 }
-
-export default RichText

--- a/src/components/partials/SliceZone/components/RichText/index.js
+++ b/src/components/partials/SliceZone/components/RichText/index.js
@@ -1,14 +1,9 @@
 import React from "react"
 import { RichText as PrismicRichText } from "prismic-reactjs"
-import { Box } from "@rent_avail/layout"
 import htmlSerializer from "./html-serializer"
 
-export default function RichText({ render, heading, ...props }) {
-  return heading ? (
+export default function RichText({ render, ...props }) {
+  return (
     <PrismicRichText render={render} htmlSerializer={htmlSerializer(props)} />
-  ) : (
-    <Box className="rich-text">
-      <PrismicRichText render={render} htmlSerializer={htmlSerializer(props)} />
-    </Box>
   )
 }

--- a/src/components/partials/SliceZone/components/ShowcaseSlice/index.js
+++ b/src/components/partials/SliceZone/components/ShowcaseSlice/index.js
@@ -1,6 +1,6 @@
 import React from "react"
 import Showcase from "components/organisms/Showcase"
-import { CONTAINER_WIDTHS, H3_SIZING } from "config"
+import { CONTAINER_WIDTHS, Typography } from "config"
 import Anchor from "components/elements/Anchor"
 import RichText from "../RichText"
 
@@ -21,9 +21,8 @@ const ShowcaseSlice = ({ slice }) => {
             <RichText
               color="blue_500"
               render={title}
-              heading
               mb="2rem"
-              {...H3_SIZING}
+              sx={{ ...Typography.H3 }}
             />
             <RichText render={description} />
           </React.Fragment>

--- a/src/components/partials/SliceZone/components/ShowcaseSlice/index.js
+++ b/src/components/partials/SliceZone/components/ShowcaseSlice/index.js
@@ -1,6 +1,6 @@
 import React from "react"
 import Showcase from "components/organisms/Showcase"
-import { CONTAINER_WIDTHS, Typography } from "config"
+import { CONTAINER_WIDTHS, STYLING } from "config"
 import Anchor from "components/elements/Anchor"
 import RichText from "../RichText"
 
@@ -22,7 +22,7 @@ const ShowcaseSlice = ({ slice }) => {
               color="blue_500"
               render={title}
               mb="2rem"
-              sx={{ ...Typography.H3 }}
+              sx={{ ...STYLING.title }}
             />
             <RichText render={description} />
           </React.Fragment>

--- a/src/components/partials/SliceZone/components/TestimonialsSlice/index.js
+++ b/src/components/partials/SliceZone/components/TestimonialsSlice/index.js
@@ -1,6 +1,6 @@
 import React from "react"
 import { Testimonials } from "components/organisms/Testimonials"
-import { CONTAINER_WIDTHS } from "config"
+import { CONTAINER_WIDTHS, STYLING } from "config"
 import RichText from "../RichText"
 
 const TestimonialsSlice = ({ slice }) => {
@@ -26,7 +26,7 @@ const TestimonialsSlice = ({ slice }) => {
 
   return (
     <Testimonials
-      title={<RichText render={title} heading />}
+      title={<RichText render={title} sx={{ ...STYLING.headline }} heading />}
       testimonials={testimonials}
       containerWidth={CONTAINER_WIDTHS}
       bg={background}

--- a/src/config.js
+++ b/src/config.js
@@ -2,26 +2,34 @@ export const CONTAINER_WIDTHS = ["62rem", "62rem", "62rem", "80rem", "96rem"]
 
 export const BREAKPOINTS = ["480px", "720px", "960px", "1200px", "1440px"]
 
-export const Typography = {
-  H1: {
+export const STYLING = {
+  hero: {
     text: ["title", "headline", "hero"],
     fontWeight: ["regular", "regular", "light"],
   },
-  H2: {
+  headline: {
     text: ["title", "title", "headline"],
     fontWeight: ["regular"],
   },
-  H3: {
+  title: {
     text: ["subtitle", "subtitle", "title"],
     fontWeight: ["regular"],
   },
-  H4: {
-    text: "subtitle",
+  subtitle: {
+    text: ["subtitle"],
     fontWeight: "regular",
   },
-  H5: {
-    text: "body",
+  body__emphasis: {
+    text: ["body"],
     fontWeight: "black",
+  },
+  body: {
+    text: ["body"],
+    fontWeight: "regular",
+  },
+  small: {
+    text: ["small"],
+    fontWeight: "regular",
   },
 }
 

--- a/src/config.js
+++ b/src/config.js
@@ -1,20 +1,28 @@
-import { theme } from "@rent_avail/base"
-
-const { fontSizes: fs, fontWeights: fw } = theme
-
 export const CONTAINER_WIDTHS = ["62rem", "62rem", "62rem", "80rem", "96rem"]
 
 export const BREAKPOINTS = ["480px", "720px", "960px", "1200px", "1440px"]
 
-export const H1_SIZING = {
-  fontSize: [fs.title, fs.headline, fs.hero],
-  fontWeight: [fw.regular, fw.regular, fs.light],
-}
-export const H2_SIZING = {
-  fontSize: [fs.title, fs.title, fs.headline],
-}
-export const H3_SIZING = {
-  fontSize: [fs.subtitle, fs.subtitle, fs.title],
+export const Typography = {
+  H1: {
+    text: ["title", "headline", "hero"],
+    fontWeight: ["regular", "regular", "light"],
+  },
+  H2: {
+    text: ["title", "title", "headline"],
+    fontWeight: ["regular"],
+  },
+  H3: {
+    text: ["subtitle", "subtitle", "title"],
+    fontWeight: ["regular"],
+  },
+  H4: {
+    text: "subtitle",
+    fontWeight: "regular",
+  },
+  H5: {
+    text: "body",
+    fontWeight: "black",
+  },
 }
 
 export const DEFAULT_SEO = {

--- a/src/types/info.json
+++ b/src/types/info.json
@@ -56,7 +56,7 @@
               "placeholder_false" : "Default",
               "placeholder_true" : "Primary",
               "default_value" : false,
-              "label" : "Button variant"
+              "label" : "Button variant (note: there should be only one primary button)"
             }
           },
           "push" : {
@@ -67,14 +67,6 @@
               "default_value" : false
             },
             "type" : "Boolean"
-          },
-          "breakpoint" : {
-            "type" : "Select",
-            "config" : {
-              "options" : [ "Always show", "480px", "720px", "960px", "1200px", "1440px" ],
-              "default_value" : "Always show",
-              "label" : "Hide button on devices smaller than"
-            }
           }
         },
         "label" : "Nav Bar Buttons"
@@ -86,12 +78,187 @@
       "config" : {
         "labels" : {
           "email_capture" : [ ],
+          "faq" : [ ],
+          "hero" : [ ],
           "hero_unit" : [ ],
           "how_it_works" : [ ],
           "pitch_cards" : [ ],
-          "show_case" : [ ]
+          "show_case" : [ ],
+          "testimonials" : [ ]
         },
         "choices" : {
+          "faq" : {
+            "type" : "Slice",
+            "fieldset" : "FAQ",
+            "description" : "A box that displays frequently asked questions and its answers",
+            "icon" : "help_outline",
+            "display" : "list",
+            "non-repeat" : {
+              "title" : {
+                "type" : "StructuredText",
+                "config" : {
+                  "single" : "heading1, heading2, heading3, heading4, heading5, heading6, strong, em",
+                  "allowTargetBlank" : true,
+                  "label" : "Title",
+                  "placeholder" : "Title",
+                  "labels" : [ "Typography: H1", "Typography: H2", "Typography: H3", "Typography: H4", "Typography: H5" ]
+                }
+              },
+              "description" : {
+                "type" : "StructuredText",
+                "config" : {
+                  "multi" : "paragraph, heading3, heading4, heading5, heading6, strong, em, hyperlink, list-item, o-list-item",
+                  "allowTargetBlank" : true,
+                  "label" : "Description",
+                  "placeholder" : "Description",
+                  "labels" : [ "Typography: H1", "Typography: H2", "Typography: H3", "Typography: H4", "Typography: H5" ]
+                }
+              },
+              "background" : {
+                "type" : "Select",
+                "config" : {
+                  "options" : [ "ui_100", "ui_300", "ui_500", "blue_100", "blue_300", "blue_500" ],
+                  "default_value" : "ui_100",
+                  "label" : "Background color"
+                }
+              },
+              "color" : {
+                "type" : "Select",
+                "config" : {
+                  "options" : [ "ui_900", "ui_700", "ui_500", "ui_300", "ui_100" ],
+                  "default_value" : "ui_900",
+                  "label" : "Text color"
+                }
+              },
+              "eyebrow" : {
+                "type" : "StructuredText",
+                "config" : {
+                  "multi" : "paragraph, heading3, heading4, heading5, heading6, strong, em, hyperlink, list-item, o-list-item",
+                  "allowTargetBlank" : true,
+                  "label" : "Eyebrow",
+                  "placeholder" : "Eyebrow"
+                }
+              }
+            },
+            "repeat" : {
+              "question" : {
+                "type" : "Text",
+                "config" : {
+                  "label" : "Question",
+                  "placeholder" : "How much does it costs?"
+                }
+              },
+              "answer" : {
+                "type" : "StructuredText",
+                "config" : {
+                  "label" : "Answer",
+                  "placeholder" : "It costs nothing! Its free!",
+                  "allowTargetBlank" : true,
+                  "multi" : "paragraph, heading3, heading4, heading5, heading6, strong, em, hyperlink, list-item, o-list-item",
+                  "labels" : [ "Typography: H1", "Typography: H2", "Typography: H3", "Typography: H4", "Typography: H5" ]
+                }
+              }
+            }
+          },
+          "hero" : {
+            "type" : "Slice",
+            "fieldset" : "Hero",
+            "description" : "A hero unit with action buttons",
+            "icon" : "chrome_reader_mode",
+            "display" : "list",
+            "non-repeat" : {
+              "title" : {
+                "type" : "StructuredText",
+                "config" : {
+                  "single" : "heading1, heading2, heading3, heading4, heading5, heading6, strong, em",
+                  "allowTargetBlank" : true,
+                  "label" : "Title",
+                  "placeholder" : "Title",
+                  "labels" : [ "Typography: H1", "Typography: H2", "Typography: H3", "Typography: H4", "Typography: H5" ]
+                }
+              },
+              "description" : {
+                "type" : "StructuredText",
+                "config" : {
+                  "multi" : "paragraph, heading3, heading4, heading5, heading6, strong, em, hyperlink, list-item, o-list-item",
+                  "allowTargetBlank" : true,
+                  "label" : "Description",
+                  "placeholder" : "Description",
+                  "labels" : [ "Typography: H1", "Typography: H2", "Typography: H3", "Typography: H4", "Typography: H5" ]
+                }
+              },
+              "background" : {
+                "type" : "Select",
+                "config" : {
+                  "options" : [ "ui_100", "ui_300", "ui_500", "blue_100", "blue_300", "blue_500" ],
+                  "default_value" : "ui_100",
+                  "label" : "Background color"
+                }
+              },
+              "color" : {
+                "type" : "Select",
+                "config" : {
+                  "options" : [ "ui_900", "ui_700", "ui_500", "ui_300", "ui_100" ],
+                  "default_value" : "ui_900",
+                  "label" : "Text color"
+                }
+              },
+              "skew" : {
+                "config" : {
+                  "label" : "Skew",
+                  "placeholder" : "",
+                  "default_value" : "right",
+                  "options" : [ "right", "left" ]
+                },
+                "type" : "Select"
+              },
+              "image" : {
+                "config" : {
+                  "label" : "Image",
+                  "constraint" : { },
+                  "thumbnails" : [ ]
+                },
+                "type" : "Image"
+              },
+              "imagePosition" : {
+                "type" : "Select",
+                "config" : {
+                  "options" : [ "right", "left" ],
+                  "default_value" : "right",
+                  "label" : "Image position"
+                }
+              },
+              "primaryButtonText" : {
+                "type" : "Text",
+                "config" : {
+                  "label" : "Primary Button Text",
+                  "placeholder" : "Get Started"
+                }
+              },
+              "primaryButtonLink" : {
+                "type" : "Link",
+                "config" : {
+                  "allowTargetBlank" : true,
+                  "label" : "Primary Button Link"
+                }
+              },
+              "secondaryButtonText" : {
+                "type" : "Text",
+                "config" : {
+                  "label" : "Secondary Button Text",
+                  "placeholder" : "Get Started"
+                }
+              },
+              "secondaryButtonLink" : {
+                "type" : "Link",
+                "config" : {
+                  "allowTargetBlank" : true,
+                  "label" : "Secondary Button Link"
+                }
+              }
+            },
+            "repeat" : { }
+          },
           "hero_unit" : {
             "type" : "Slice",
             "fieldset" : "Hero w/ Email Capture",
@@ -105,7 +272,8 @@
                   "single" : "heading1, heading2, heading3, heading4, heading5, heading6, strong, em",
                   "allowTargetBlank" : true,
                   "label" : "Title",
-                  "placeholder" : "Title"
+                  "placeholder" : "Title",
+                  "labels" : [ "Typography: H1", "Typography: H2", "Typography: H3", "Typography: H4", "Typography: H5" ]
                 }
               },
               "description" : {
@@ -114,7 +282,8 @@
                   "multi" : "paragraph, heading3, heading4, heading5, heading6, strong, em, hyperlink, list-item, o-list-item",
                   "allowTargetBlank" : true,
                   "label" : "Description",
-                  "placeholder" : "Description"
+                  "placeholder" : "Description",
+                  "labels" : [ "Typography: H1", "Typography: H2", "Typography: H3", "Typography: H4", "Typography: H5" ]
                 }
               },
               "background" : {
@@ -195,7 +364,8 @@
                   "single" : "heading1, heading2, heading3, heading4, heading5, heading6, strong, em",
                   "allowTargetBlank" : true,
                   "label" : "Title",
-                  "placeholder" : "Title"
+                  "placeholder" : "Title",
+                  "labels" : [ "Typography: H1", "Typography: H2", "Typography: H3", "Typography: H4", "Typography: H5" ]
                 }
               },
               "titleImage" : {
@@ -221,7 +391,8 @@
                   "multi" : "paragraph, heading3, heading4, heading5, heading6, strong, em, hyperlink, list-item, o-list-item",
                   "allowTargetBlank" : true,
                   "label" : "Description",
-                  "placeholder" : "Description"
+                  "placeholder" : "Description",
+                  "labels" : [ "Typography: H1", "Typography: H2", "Typography: H3", "Typography: H4", "Typography: H5" ]
                 }
               }
             },
@@ -232,7 +403,8 @@
                   "single" : "heading3, heading4, heading5, heading6, strong, em",
                   "allowTargetBlank" : true,
                   "label" : "Title",
-                  "placeholder" : "Card title"
+                  "placeholder" : "Card title",
+                  "labels" : [ "Typography: H1", "Typography: H2", "Typography: H3", "Typography: H4", "Typography: H5" ]
                 }
               },
               "centerTitle" : {
@@ -250,7 +422,8 @@
                   "multi" : "paragraph, heading3, heading4, heading5, heading6, strong, em, hyperlink, list-item, o-list-item",
                   "allowTargetBlank" : true,
                   "label" : "Description",
-                  "placeholder" : "Card description"
+                  "placeholder" : "Card description",
+                  "labels" : [ "Typography: H1", "Typography: H2", "Typography: H3", "Typography: H4", "Typography: H5" ]
                 }
               },
               "icon" : {
@@ -307,7 +480,8 @@
                   "single" : "heading1, heading2, heading3, heading4, heading5, heading6, strong, em",
                   "allowTargetBlank" : true,
                   "label" : "Title",
-                  "placeholder" : "Title"
+                  "placeholder" : "Title",
+                  "labels" : [ "Typography: H1", "Typography: H2", "Typography: H3", "Typography: H4", "Typography: H5" ]
                 }
               },
               "background" : {
@@ -336,7 +510,8 @@
                   "single" : "heading1, heading2, heading3, heading4, heading5, heading6, strong, em",
                   "allowTargetBlank" : true,
                   "label" : "Title",
-                  "placeholder" : "Section title"
+                  "placeholder" : "Section title",
+                  "labels" : [ "Typography: H1", "Typography: H2", "Typography: H3", "Typography: H4", "Typography: H5" ]
                 }
               },
               "description" : {
@@ -345,7 +520,8 @@
                   "multi" : "paragraph, preformatted, heading3, heading4, heading5, heading6, strong, em, hyperlink, list-item, o-list-item",
                   "allowTargetBlank" : true,
                   "label" : "Description",
-                  "placeholder" : "Section description"
+                  "placeholder" : "Section description",
+                  "labels" : [ "Typography: H1", "Typography: H2", "Typography: H3", "Typography: H4", "Typography: H5" ]
                 }
               },
               "image" : {
@@ -378,7 +554,8 @@
                   "single" : "heading1, heading2, heading3, heading4, heading5, heading6, strong, em",
                   "allowTargetBlank" : true,
                   "label" : "Title",
-                  "placeholder" : "Title"
+                  "placeholder" : "Title",
+                  "labels" : [ "Typography: H1", "Typography: H2", "Typography: H3", "Typography: H4", "Typography: H5" ]
                 }
               },
               "description" : {
@@ -387,7 +564,8 @@
                   "multi" : "paragraph, heading3, heading4, heading5, heading6, strong, em, hyperlink, list-item, o-list-item",
                   "allowTargetBlank" : true,
                   "label" : "Description",
-                  "placeholder" : "Description"
+                  "placeholder" : "Description",
+                  "labels" : [ "Typography: H1", "Typography: H2", "Typography: H3", "Typography: H4", "Typography: H5" ]
                 }
               },
               "image" : {
@@ -423,7 +601,8 @@
                   "label" : "Copy",
                   "placeholder" : "",
                   "allowTargetBlank" : true,
-                  "multi" : "paragraph, strong, em, hyperlink, list-item, o-list-item"
+                  "multi" : "paragraph, strong, em, hyperlink, list-item, o-list-item",
+                  "labels" : [ "Typography: H1", "Typography: H2", "Typography: H3", "Typography: H4", "Typography: H5" ]
                 },
                 "type" : "StructuredText"
               }
@@ -449,7 +628,8 @@
                   "single" : "heading1, heading2, heading3, heading4, heading5, heading6, strong, em",
                   "allowTargetBlank" : true,
                   "label" : "Title",
-                  "placeholder" : "Title"
+                  "placeholder" : "Title",
+                  "labels" : [ "Typography: H1", "Typography: H2", "Typography: H3", "Typography: H4", "Typography: H5" ]
                 }
               },
               "label" : {
@@ -468,6 +648,92 @@
               }
             },
             "repeat" : { }
+          },
+          "testimonials" : {
+            "type" : "Slice",
+            "fieldset" : "Testimonials",
+            "description" : "A list that displays quotes and its authors",
+            "icon" : "format_quote",
+            "display" : "grid",
+            "non-repeat" : {
+              "title" : {
+                "type" : "StructuredText",
+                "config" : {
+                  "single" : "heading1, heading2, heading3, heading4, heading5, heading6",
+                  "label" : "Title",
+                  "placeholder" : "Testimonials Title",
+                  "labels" : [ "Typography: H1", "Typography: H2", "Typography: H3", "Typography: H4", "Typography: H5" ]
+                }
+              },
+              "background" : {
+                "type" : "Select",
+                "config" : {
+                  "options" : [ "ui_100", "ui_300", "ui_500", "blue_100", "blue_300", "blue_500" ],
+                  "default_value" : "ui_100",
+                  "label" : "Background color"
+                }
+              },
+              "color" : {
+                "type" : "Select",
+                "config" : {
+                  "options" : [ "ui_900", "ui_700", "ui_500", "ui_300", "ui_100" ],
+                  "default_value" : "ui_900",
+                  "label" : "Text color"
+                }
+              },
+              "testimonialBackground" : {
+                "type" : "Select",
+                "config" : {
+                  "options" : [ "ui_100", "ui_300", "ui_500", "blue_100", "blue_300", "blue_500" ],
+                  "default_value" : "ui_100",
+                  "label" : "Testimonial Background color"
+                }
+              },
+              "testimonialColor" : {
+                "type" : "Select",
+                "config" : {
+                  "options" : [ "ui_900", "ui_700", "ui_500", "ui_300", "ui_100" ],
+                  "default_value" : "ui_900",
+                  "label" : "Testimonial Text color"
+                }
+              }
+            },
+            "repeat" : {
+              "picture" : {
+                "type" : "Image",
+                "config" : {
+                  "constraint" : {
+                    "width" : 48,
+                    "height" : 48
+                  },
+                  "thumbnails" : [ ],
+                  "label" : "Author Picture"
+                }
+              },
+              "author" : {
+                "type" : "Text",
+                "config" : {
+                  "label" : "Author Name",
+                  "placeholder" : "Jhon Smith"
+                }
+              },
+              "titleAndLocation" : {
+                "type" : "Text",
+                "config" : {
+                  "label" : "Title and Location",
+                  "placeholder" : "Landlord in Chicago, Illinois"
+                }
+              },
+              "quote" : {
+                "type" : "StructuredText",
+                "config" : {
+                  "multi" : "paragraph, preformatted, heading1, heading2, heading3, heading4, heading5, heading6, strong, em, hyperlink, list-item, o-list-item, rtl",
+                  "label" : "Quote",
+                  "placeholder" : "Lorem ipsum sit dolor amet",
+                  "labels" : [ "Typography: H1", "Typography: H2", "Typography: H3", "Typography: H4", "Typography: H5" ]
+                }
+              }
+            }
           }
         }
       }

--- a/src/types/info.json
+++ b/src/types/info.json
@@ -101,7 +101,7 @@
                   "allowTargetBlank" : true,
                   "label" : "Title",
                   "placeholder" : "Title",
-                  "labels" : [ "Typography: H1", "Typography: H2", "Typography: H3", "Typography: H4", "Typography: H5" ]
+                  "labels" : [ "hero", "headline", "title", "subtitle", "body__emphasis", "body", "small" ]
                 }
               },
               "description" : {
@@ -111,7 +111,7 @@
                   "allowTargetBlank" : true,
                   "label" : "Description",
                   "placeholder" : "Description",
-                  "labels" : [ "Typography: H1", "Typography: H2", "Typography: H3", "Typography: H4", "Typography: H5" ]
+                  "labels" : [ "hero", "headline", "title", "subtitle", "body__emphasis", "body", "small" ]
                 }
               },
               "background" : {
@@ -155,7 +155,7 @@
                   "placeholder" : "It costs nothing! Its free!",
                   "allowTargetBlank" : true,
                   "multi" : "paragraph, heading3, heading4, heading5, heading6, strong, em, hyperlink, list-item, o-list-item",
-                  "labels" : [ "Typography: H1", "Typography: H2", "Typography: H3", "Typography: H4", "Typography: H5" ]
+                  "labels" : [ "hero", "headline", "title", "subtitle", "body__emphasis", "body", "small" ]
                 }
               }
             }
@@ -174,7 +174,7 @@
                   "allowTargetBlank" : true,
                   "label" : "Title",
                   "placeholder" : "Title",
-                  "labels" : [ "Typography: H1", "Typography: H2", "Typography: H3", "Typography: H4", "Typography: H5" ]
+                  "labels" : [ "hero", "headline", "title", "subtitle", "body__emphasis", "body", "small" ]
                 }
               },
               "description" : {
@@ -184,7 +184,7 @@
                   "allowTargetBlank" : true,
                   "label" : "Description",
                   "placeholder" : "Description",
-                  "labels" : [ "Typography: H1", "Typography: H2", "Typography: H3", "Typography: H4", "Typography: H5" ]
+                  "labels" : [ "hero", "headline", "title", "subtitle", "body__emphasis", "body", "small" ]
                 }
               },
               "background" : {
@@ -273,7 +273,7 @@
                   "allowTargetBlank" : true,
                   "label" : "Title",
                   "placeholder" : "Title",
-                  "labels" : [ "Typography: H1", "Typography: H2", "Typography: H3", "Typography: H4", "Typography: H5" ]
+                  "labels" : [ "hero", "headline", "title", "subtitle", "body__emphasis", "body", "small" ]
                 }
               },
               "description" : {
@@ -283,7 +283,7 @@
                   "allowTargetBlank" : true,
                   "label" : "Description",
                   "placeholder" : "Description",
-                  "labels" : [ "Typography: H1", "Typography: H2", "Typography: H3", "Typography: H4", "Typography: H5" ]
+                  "labels" : [ "hero", "headline", "title", "subtitle", "body__emphasis", "body", "small" ]
                 }
               },
               "background" : {
@@ -365,7 +365,7 @@
                   "allowTargetBlank" : true,
                   "label" : "Title",
                   "placeholder" : "Title",
-                  "labels" : [ "Typography: H1", "Typography: H2", "Typography: H3", "Typography: H4", "Typography: H5" ]
+                  "labels" : [ "hero", "headline", "title", "subtitle", "body__emphasis", "body", "small" ]
                 }
               },
               "titleImage" : {
@@ -392,7 +392,7 @@
                   "allowTargetBlank" : true,
                   "label" : "Description",
                   "placeholder" : "Description",
-                  "labels" : [ "Typography: H1", "Typography: H2", "Typography: H3", "Typography: H4", "Typography: H5" ]
+                  "labels" : [ "hero", "headline", "title", "subtitle", "body__emphasis", "body", "small" ]
                 }
               }
             },
@@ -404,7 +404,7 @@
                   "allowTargetBlank" : true,
                   "label" : "Title",
                   "placeholder" : "Card title",
-                  "labels" : [ "Typography: H1", "Typography: H2", "Typography: H3", "Typography: H4", "Typography: H5" ]
+                  "labels" : [ "hero", "headline", "title", "subtitle", "body__emphasis", "body", "small" ]
                 }
               },
               "centerTitle" : {
@@ -423,7 +423,7 @@
                   "allowTargetBlank" : true,
                   "label" : "Description",
                   "placeholder" : "Card description",
-                  "labels" : [ "Typography: H1", "Typography: H2", "Typography: H3", "Typography: H4", "Typography: H5" ]
+                  "labels" : [ "hero", "headline", "title", "subtitle", "body__emphasis", "body", "small" ]
                 }
               },
               "icon" : {
@@ -481,7 +481,7 @@
                   "allowTargetBlank" : true,
                   "label" : "Title",
                   "placeholder" : "Title",
-                  "labels" : [ "Typography: H1", "Typography: H2", "Typography: H3", "Typography: H4", "Typography: H5" ]
+                  "labels" : [ "hero", "headline", "title", "subtitle", "body__emphasis", "body", "small" ]
                 }
               },
               "background" : {
@@ -511,7 +511,7 @@
                   "allowTargetBlank" : true,
                   "label" : "Title",
                   "placeholder" : "Section title",
-                  "labels" : [ "Typography: H1", "Typography: H2", "Typography: H3", "Typography: H4", "Typography: H5" ]
+                  "labels" : [ "hero", "headline", "title", "subtitle", "body__emphasis", "body", "small" ]
                 }
               },
               "description" : {
@@ -521,7 +521,7 @@
                   "allowTargetBlank" : true,
                   "label" : "Description",
                   "placeholder" : "Section description",
-                  "labels" : [ "Typography: H1", "Typography: H2", "Typography: H3", "Typography: H4", "Typography: H5" ]
+                  "labels" : [ "hero", "headline", "title", "subtitle", "body__emphasis", "body", "small" ]
                 }
               },
               "image" : {
@@ -555,7 +555,7 @@
                   "allowTargetBlank" : true,
                   "label" : "Title",
                   "placeholder" : "Title",
-                  "labels" : [ "Typography: H1", "Typography: H2", "Typography: H3", "Typography: H4", "Typography: H5" ]
+                  "labels" : [ "hero", "headline", "title", "subtitle", "body__emphasis", "body", "small" ]
                 }
               },
               "description" : {
@@ -565,7 +565,7 @@
                   "allowTargetBlank" : true,
                   "label" : "Description",
                   "placeholder" : "Description",
-                  "labels" : [ "Typography: H1", "Typography: H2", "Typography: H3", "Typography: H4", "Typography: H5" ]
+                  "labels" : [ "hero", "headline", "title", "subtitle", "body__emphasis", "body", "small" ]
                 }
               },
               "image" : {
@@ -602,7 +602,7 @@
                   "placeholder" : "",
                   "allowTargetBlank" : true,
                   "multi" : "paragraph, strong, em, hyperlink, list-item, o-list-item",
-                  "labels" : [ "Typography: H1", "Typography: H2", "Typography: H3", "Typography: H4", "Typography: H5" ]
+                  "labels" : [ "hero", "headline", "title", "subtitle", "body__emphasis", "body", "small" ]
                 },
                 "type" : "StructuredText"
               }
@@ -629,7 +629,7 @@
                   "allowTargetBlank" : true,
                   "label" : "Title",
                   "placeholder" : "Title",
-                  "labels" : [ "Typography: H1", "Typography: H2", "Typography: H3", "Typography: H4", "Typography: H5" ]
+                  "labels" : [ "hero", "headline", "title", "subtitle", "body__emphasis", "body", "small" ]
                 }
               },
               "label" : {
@@ -662,7 +662,7 @@
                   "single" : "heading1, heading2, heading3, heading4, heading5, heading6",
                   "label" : "Title",
                   "placeholder" : "Testimonials Title",
-                  "labels" : [ "Typography: H1", "Typography: H2", "Typography: H3", "Typography: H4", "Typography: H5" ]
+                  "labels" : [ "hero", "headline", "title", "subtitle", "body__emphasis", "body", "small" ]
                 }
               },
               "background" : {
@@ -695,6 +695,14 @@
                   "options" : [ "ui_900", "ui_700", "ui_500", "ui_300", "ui_100" ],
                   "default_value" : "ui_900",
                   "label" : "Testimonial Text color"
+                }
+              },
+              "skew" : {
+                "type" : "Select",
+                "config" : {
+                  "options" : [ "none", "right", "left" ],
+                  "default_value" : "none",
+                  "label" : "Skew"
                 }
               }
             },
@@ -730,7 +738,7 @@
                   "multi" : "paragraph, preformatted, heading1, heading2, heading3, heading4, heading5, heading6, strong, em, hyperlink, list-item, o-list-item, rtl",
                   "label" : "Quote",
                   "placeholder" : "Lorem ipsum sit dolor amet",
-                  "labels" : [ "Typography: H1", "Typography: H2", "Typography: H3", "Typography: H4", "Typography: H5" ]
+                  "labels" : [ "hero", "headline", "title", "subtitle", "body__emphasis", "body", "small" ]
                 }
               }
             }

--- a/yarn.lock
+++ b/yarn.lock
@@ -190,6 +190,15 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
+"@babel/eslint-parser@^7.12.1":
+  version "7.12.1"
+  resolved "https://registry.yarnpkg.com/@babel/eslint-parser/-/eslint-parser-7.12.1.tgz#b3ae38e6174d2d0d2d00d2dcd919b4086b6bb8f0"
+  integrity sha512-cc7WQHnHQY3++/bghgbDtPx+5bf6xTsokyGzV6Qzh65NLz/unv+mPQuACkQ9GFhIhcTFv6yqwNaEcfX7EkOEsg==
+  dependencies:
+    eslint-scope "5.1.0"
+    eslint-visitor-keys "^1.3.0"
+    semver "^6.3.0"
+
 "@babel/generator@^7.10.1":
   version "7.10.2"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.10.2.tgz#0fa5b5b2389db8bfdfcc3492b551ee20f5dd69a9"
@@ -558,7 +567,7 @@
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.12.11.tgz#9ce3595bcd74bc5c466905e86c535b8b25011e79"
   integrity sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg==
 
-"@babel/parser@^7.12.3", "@babel/parser@^7.12.5", "@babel/parser@^7.7.0":
+"@babel/parser@^7.12.3", "@babel/parser@^7.12.5":
   version "7.12.5"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.12.5.tgz#b4af32ddd473c0bfa643bd7ff0728b8e71b81ea0"
   integrity sha512-FVM6RZQ0mn2KCf1VUED7KepYeUWoVShczewOCfm3nzoBybaih51h+sYVVGthW9M6lPByEPTQf+xm27PBdlpwmQ==
@@ -1324,7 +1333,7 @@
     globals "^11.1.0"
     lodash "^4.17.19"
 
-"@babel/traverse@^7.12.1", "@babel/traverse@^7.12.5", "@babel/traverse@^7.7.0":
+"@babel/traverse@^7.12.1", "@babel/traverse@^7.12.5":
   version "7.12.5"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.12.5.tgz#78a0c68c8e8a35e4cacfd31db8bb303d5606f095"
   integrity sha512-xa15FbQnias7z9a62LwYAA5SZZPkHIXpd42C6uW68o8uTuua96FHZy1y61Va5P/i83FAAcMpW8+A/QayntzuqA==
@@ -1396,7 +1405,7 @@
     lodash "^4.17.19"
     to-fast-properties "^2.0.0"
 
-"@babel/types@^7.12.1", "@babel/types@^7.12.5", "@babel/types@^7.7.0":
+"@babel/types@^7.12.1", "@babel/types@^7.12.5":
   version "7.12.6"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.12.6.tgz#ae0e55ef1cce1fbc881cd26f8234eb3e657edc96"
   integrity sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==
@@ -3660,18 +3669,6 @@ babel-code-frame@^6.22.0:
     chalk "^1.1.3"
     esutils "^2.0.2"
     js-tokens "^3.0.2"
-
-babel-eslint@^10.1.0:
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-10.1.0.tgz#6968e568a910b78fb3779cdd8b6ac2f479943232"
-  integrity sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==
-  dependencies:
-    "@babel/code-frame" "^7.0.0"
-    "@babel/parser" "^7.7.0"
-    "@babel/traverse" "^7.7.0"
-    "@babel/types" "^7.7.0"
-    eslint-visitor-keys "^1.0.0"
-    resolve "^1.12.0"
 
 babel-helper-evaluate-path@^0.5.0:
   version "0.5.0"
@@ -6183,6 +6180,14 @@ eslint-plugin-react@^7.21.5:
     resolve "^1.18.1"
     string.prototype.matchall "^4.0.2"
 
+eslint-scope@5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.0.tgz#d0f971dfe59c69e0cada684b23d49dbf82600ce5"
+  integrity sha512-iiGRvtxWqgtx5m8EyQUJihBloE4EnYeGE/bz1wSPwJE6tZuJUtHlhqDM4Xj2ukE8Dyy1+HCZ4hE0fzIVMzb58w==
+  dependencies:
+    esrecurse "^4.1.0"
+    estraverse "^4.1.1"
+
 eslint-scope@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.3.tgz#ca03833310f6889a3264781aa82e63eb9cfe7848"
@@ -6206,7 +6211,7 @@ eslint-utils@^2.1.0:
   dependencies:
     eslint-visitor-keys "^1.1.0"
 
-eslint-visitor-keys@^1.0.0, eslint-visitor-keys@^1.1.0, eslint-visitor-keys@^1.3.0:
+eslint-visitor-keys@^1.1.0, eslint-visitor-keys@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz#30ebd1ef7c2fdff01c3a4f151044af25fab0523e"
   integrity sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==


### PR DESCRIPTION
**Resolves**

[Airtable - Separate Font Size from Heading](https://airtable.com/tbl4CgbPGPmsSc1pl/viwkpIRDfH7ure4zB/recf0AtqFMUD3zrtn)

**Why**

- Semantic headings hierarchy is important for the SEO, but in practice this hierarchy rarely matches the visual one. This call for separation of semantic H1...H5 from influencing the visual presentation of these headings. In other words, in actual CMS circumstances we might need to have H2 that look like H5

**Solution**

- Set default heading sizing for components/slices that have explicit headings, disregarding the tag itself
- Allow content editors to override default component sizing, as well as default sizing of Rich Text headers via Prismic Labels

**Also Included**

- Switches all headings usage to `<Box as="h{x}" />` to gain acess to `sx`
- Various tweaks and adjustments of spacing
- Switched `babel-eslint` to `@babel/eslint-parser` for optional chaining support, - there are some anecdotes that Babel parser is no longer needed for ESLint, but have no time to verify
- Fixes messy FAQ slice markup

**Screenshots**
- Prismic labels
![Screenshot_20210105_144437](https://user-images.githubusercontent.com/1927171/103647820-8dd80300-4f64-11eb-9f5c-8f6c1f2ea2eb.png)

**Notes**

Regarding Prismic labels format and corresponding config entries: the goal was to make it a bit more idiomatic for CMS users, as well as abstract it a little from the theme / design system specifics, keeping it open for extension.

