### PR TITLE
Add info-dev type for early development / experiments with Prismic

### DIFF
--- a/pages/_lib.js
+++ b/pages/_lib.js
@@ -1,0 +1,27 @@
+import Prismic from "prismic-javascript"
+import { prismicClient } from "src/prismic.config"
+
+export const useGetStaticProps = (type) => async ({
+  preview = null,
+  previewData = {},
+  params: { uid },
+}) => {
+  const data = await prismicClient.getByUID(type, uid, { ...previewData })
+  return {
+    props: {
+      preview,
+      previewData,
+      ...data,
+    },
+    revalidate: 1,
+  }
+}
+
+export const useGetStaticPaths = (type) => async () => {
+  const pages = await prismicClient.query(
+    Prismic.Predicates.at("document.type", type),
+    { pageSize: 100 }
+  )
+  const paths = pages.results.map((p) => `/${type}/${p.uid}`)
+  return { paths, fallback: true }
+}

--- a/pages/info-dev/[uid].js
+++ b/pages/info-dev/[uid].js
@@ -1,4 +1,4 @@
-import { useGetStaticPaths, useGetStaticProps } from "../_lib"
+import { useGetStaticPaths, useGetStaticProps } from "src/next.helpers"
 
 export const getStaticProps = useGetStaticProps("info-dev")
 

--- a/pages/info-dev/[uid].js
+++ b/pages/info-dev/[uid].js
@@ -1,0 +1,7 @@
+import { useGetStaticPaths, useGetStaticProps } from "../_lib"
+
+export const getStaticProps = useGetStaticProps("info-dev")
+
+export const getStaticPaths = useGetStaticPaths("info-dev")
+
+export { default } from "../info/[uid]"

--- a/pages/info/[uid].js
+++ b/pages/info/[uid].js
@@ -1,5 +1,4 @@
 import React from "react"
-import { prismicClient } from "src/prismic.config"
 import { NextSeo } from "next-seo"
 import AvailFooter from "components/partials/AvailFooter"
 import SliceZone from "components/partials/SliceZone"
@@ -14,28 +13,11 @@ import { useRouter } from "next/router"
 import DefaultErrorPage from "next/error"
 import Head from "next/head"
 import { Box, Flex } from "@rent_avail/layout"
+import { useGetStaticPaths, useGetStaticProps } from "../_lib"
 
-export const getStaticProps = async ({
-  preview = null,
-  previewData = {},
-  params: { uid },
-}) => {
-  const data = await prismicClient.getByUID("info", uid, { ...previewData })
-  return {
-    props: {
-      preview,
-      previewData,
-      ...data,
-    },
-    revalidate: 1,
-  }
-}
+export const getStaticProps = useGetStaticProps("info")
 
-export const getStaticPaths = async () => {
-  const pages = await prismicClient.query("", { pageSize: 100 })
-  const paths = pages.results.map((p) => `/info/${p.uid}`)
-  return { paths, fallback: true }
-}
+export const getStaticPaths = useGetStaticPaths("info")
 
 const NavBarWrapper = ({ links, ...props }) => {
   const urlResolver = useUrlResolver()

--- a/pages/info/[uid].js
+++ b/pages/info/[uid].js
@@ -13,7 +13,7 @@ import { useRouter } from "next/router"
 import DefaultErrorPage from "next/error"
 import Head from "next/head"
 import { Box, Flex } from "@rent_avail/layout"
-import { useGetStaticPaths, useGetStaticProps } from "../_lib"
+import { useGetStaticPaths, useGetStaticProps } from "src/next.helpers"
 
 export const getStaticProps = useGetStaticProps("info")
 

--- a/src/next.helpers.js
+++ b/src/next.helpers.js
@@ -1,5 +1,5 @@
+import { prismicClient } from "./prismic.config"
 import Prismic from "prismic-javascript"
-import { prismicClient } from "src/prismic.config"
 
 export const useGetStaticProps = (type) => async ({
   preview = null,
@@ -16,7 +16,6 @@ export const useGetStaticProps = (type) => async ({
     revalidate: 1,
   }
 }
-
 export const useGetStaticPaths = (type) => async () => {
   const pages = await prismicClient.query(
     Prismic.Predicates.at("document.type", type),


### PR DESCRIPTION
The idea is to keep a DEV copy of the `info` content type in the Prismic as `info-dev`, so that we don't need to mutate production type for experiments during early development. This will also allow DEV pages to stand out in CMS a bit more.

In the Next app the `info-dev` will mirror implementation of `info`, hence the helpers for routing.