### PR TITLE
Allow "action buttons" to have persistent selectors for targeting in tools

### DIFF
--- a/pages/info/[uid].js
+++ b/pages/info/[uid].js
@@ -93,10 +93,11 @@ const Page = ({ data, uid }) => {
   const navBarLinks =
     data.nav_bar &&
     data.nav_bar.map(
-      ({ buttonText, buttonLink, buttonHash, primary, push }) => ({
+      ({ buttonText, buttonLink, buttonHash, buttonId, primary, push }) => ({
         text: buttonText,
         href: buttonHash ? `#${buttonHash.replace(/^#/, "")}` : buttonLink.url,
         target: buttonLink && buttonLink.target,
+        id: buttonId,
         primary,
         push,
       })

--- a/src/components/molecules/PitchCard/index.js
+++ b/src/components/molecules/PitchCard/index.js
@@ -1,10 +1,6 @@
 import * as React from "react"
-import Link from "next/link"
-import { Button } from "@rent_avail/controls"
 import { Box, Col, Flex } from "@rent_avail/layout"
-import { Text } from "@rent_avail/typography"
 import Video from "components/elements/Video"
-import { getTargetProps } from "utils/link"
 import { STYLING } from "config"
 import { useInViewAnimation } from "utils/animation"
 import { motion } from "framer-motion"
@@ -15,13 +11,17 @@ export function PitchCard({
   icon = null,
   video,
   embed,
+  variant,
   link,
   animationPreset,
   ...props
 }) {
   const [presets, intersectionView] = useInViewAnimation({ threshold: 0.25 })
   const animation = presets[animationPreset]
-  const isButtonVariant = !!link?.button
+
+  /* TODO: this "button variant" either needs to be moved outside of
+      this component or properly implemented via Styled System variants API */
+  const isButtonVariant = variant === "button"
   return (
     <Col
       as={motion.aside}
@@ -78,17 +78,7 @@ export function PitchCard({
           mt={isButtonVariant ? "3rem" : "1.5rem"}
           justifyContent={isButtonVariant ? "center" : "flex-start"}
         >
-          <Link href={link.url} passHref>
-            {isButtonVariant ? (
-              <Button as="a" {...getTargetProps(link.target)}>
-                {link.text}
-              </Button>
-            ) : (
-              <Text as="a" {...getTargetProps(link.target)} color="blue_700">
-                {link.text}
-              </Text>
-            )}
-          </Link>
+          {link}
         </Flex>
       )}
     </Col>

--- a/src/components/organisms/NavBar/index.js
+++ b/src/components/organisms/NavBar/index.js
@@ -139,10 +139,11 @@ export default function NavBar({
               gap: "2rem",
             }}
           >
-            {defaultLinks.map(({ href, text, target }, idx) => (
+            {defaultLinks.map(({ href, text, id, target }, idx) => (
               <motion.div key={href} {...animation?.item}>
                 <NavBarButton
                   href={href}
+                  id={id}
                   {...getTargetProps(target)}
                   forwardedAs="a"
                   flex="none"
@@ -159,6 +160,7 @@ export default function NavBar({
                 variant="primary"
                 href={primaryLink.href}
                 {...getTargetProps(primaryLink.target)}
+                id={primaryLink.id}
                 forwardedAs="a"
                 flex="0 0 auto"
                 ml="2rem"

--- a/src/components/organisms/PitchCards/pitch-cards.stories.js
+++ b/src/components/organisms/PitchCards/pitch-cards.stories.js
@@ -1,6 +1,8 @@
 import React from "react"
 import { Box } from "@rent_avail/layout"
 import ResponsiveEmbed from "components/elements/ResponsiveEmbed"
+import { Text } from "@rent_avail/typography"
+import { Button } from "@rent_avail/controls"
 import { PitchCards } from "./index"
 
 export default { title: "Components/Pitch Cards" }
@@ -46,22 +48,18 @@ const iconSections = sections.map((section, idx) => ({
 }))
 
 const links = [
-  {
-    text: "Advertise across the web >",
-    url: "https://www.avail.co/users/new?intent=listings",
-  },
-  {
-    text: "Find the right tenants >",
-    url: "https://www.avail.co/users/new?intent=applications",
-  },
-  {
-    text: "Start screening applicants >",
-    url: "https://www.avail.co/users/new?intent=applications",
-  },
-  {
-    text: "Send and sign today >",
-    url: "https://www.avail.co/users/new?intent=leases",
-  },
+  <Text as="a" href="https://www.avail.co/users/new?intent=listings">
+    Advertise across the web &gt;
+  </Text>,
+  <Text as="a" href="https://www.avail.co/users/new?intent=applications">
+    Find the right tenants &gt;
+  </Text>,
+  <Text as="a" href="https://www.avail.co/users/new?intent=applications">
+    Start screening applicants &gt;
+  </Text>,
+  <Text as="a" href="https://www.avail.co/users/new?intent=leases">
+    Send and sign today &gt;
+  </Text>,
 ]
 
 const linkSections = iconSections.map((section, idx) => ({
@@ -76,7 +74,8 @@ const buttonLinkSections = sectionData.map(({ title, description }, idx) => ({
     </Box>
   ),
   description,
-  link: { ...links[idx], text: "View sample", button: true },
+  link: <Button>View sample</Button>,
+  variant: "button",
 }))
 
 const videoSections = sections.slice(0, 2).map((section) => ({

--- a/src/components/partials/SliceZone/components/ButtonCTASlice/index.js
+++ b/src/components/partials/SliceZone/components/ButtonCTASlice/index.js
@@ -11,6 +11,7 @@ const ButtonCTASlice = ({ slice }) => {
       title,
       buttonText,
       buttonLink,
+      buttonId,
       background,
       color,
       orientation = "left",
@@ -27,10 +28,14 @@ const ButtonCTASlice = ({ slice }) => {
       skew={skew}
       title={title && <RichText render={title} />}
       button={
-        buttonText &&
-        buttonLink && (
+        buttonText && (
           <Link link={buttonLink}>
-            <Button forwardedAs="a" variant="primary" background={background}>
+            <Button
+              forwardedAs="a"
+              variant="primary"
+              background={background}
+              id={buttonId}
+            >
               {buttonText}
             </Button>
           </Link>

--- a/src/components/partials/SliceZone/components/HeroSlice/index.js
+++ b/src/components/partials/SliceZone/components/HeroSlice/index.js
@@ -21,15 +21,14 @@ const HeroSlice = ({ slice }) => {
       color,
       primaryButtonText,
       primaryButtonLink,
+      primaryButtonId,
       secondaryButtonText,
       secondaryButtonLink,
+      secondaryButtonId,
     },
   } = slice
 
   const buttonRef = useRef()
-
-  const showPrimaryButton = primaryButtonText && primaryButtonLink
-  const showSecondaryButton = secondaryButtonText && secondaryButtonLink
 
   return (
     <Hero
@@ -44,13 +43,14 @@ const HeroSlice = ({ slice }) => {
       video={video?.url && video}
       embed={embed?.html && <Embed embed={embed} />}
       primaryLink={
-        showPrimaryButton && (
+        primaryButtonText && (
           <Link link={primaryButtonLink}>
             <Button
               ref={buttonRef}
               forwardedAs="a"
               background={background}
               variant="primary"
+              id={primaryButtonId}
             >
               {primaryButtonText}
             </Button>
@@ -58,9 +58,11 @@ const HeroSlice = ({ slice }) => {
         )
       }
       secondaryLink={
-        showSecondaryButton && (
+        secondaryButtonText && (
           <Link link={secondaryButtonLink}>
-            <Button background={background}>{secondaryButtonText}</Button>
+            <Button background={background} id={secondaryButtonId}>
+              {secondaryButtonText}
+            </Button>
           </Link>
         )
       }

--- a/src/components/partials/SliceZone/components/Link/index.js
+++ b/src/components/partials/SliceZone/components/Link/index.js
@@ -37,13 +37,17 @@ const Link = ({ link, children, ...props }) => {
     }
   })()
 
+  const wrappedElement = React.cloneElement(children, {
+    ...getTargetProps(target),
+  })
+
   return href ? (
     <NextLink passHref href={href} {...props}>
-      {React.cloneElement(children, {
-        ...getTargetProps(target),
-      })}
+      {wrappedElement}
     </NextLink>
-  ) : null
+  ) : (
+    wrappedElement
+  )
 }
 
 export default Link

--- a/src/components/partials/SliceZone/components/PitchCardsSlice/index.js
+++ b/src/components/partials/SliceZone/components/PitchCardsSlice/index.js
@@ -3,16 +3,16 @@ import { Box } from "@rent_avail/layout"
 import { PitchCards } from "components/organisms/PitchCards"
 import Anchor from "components/elements/Anchor"
 import { CONTAINER_WIDTHS } from "config"
-import { useUrlResolver } from "components/partials/UrlResolver"
-import RichText from "../RichText"
+import Link from "components/partials/SliceZone/components/Link"
+import { Button } from "@rent_avail/controls"
+import { Text } from "@rent_avail/typography"
 import Embed from "../Embed"
+import RichText from "../RichText"
 
 const PitchCardsSlice = ({ slice }) => {
   const {
     primary: { title, titleImage, centerTitle, description, hash },
   } = slice
-
-  const urlResolver = useUrlResolver()
 
   const sections = slice.items.map(
     (
@@ -25,6 +25,7 @@ const PitchCardsSlice = ({ slice }) => {
         embed,
         linkText,
         linkUrl,
+        linkId,
         linkAsButton,
       },
       idx
@@ -41,16 +42,20 @@ const PitchCardsSlice = ({ slice }) => {
       video,
       embed: embed?.html && <Embed embed={embed} />,
       key: title?.[0]?.text || idx,
-      link:
-        linkText && linkUrl
-          ? {
-              text: linkText,
-              url: urlResolver(linkUrl.url),
-              target:
-                linkUrl.target || (linkUrl.link_type === "Media" && "_blank"),
-              button: linkAsButton,
-            }
-          : null,
+      link: linkText ? (
+        <Link link={linkUrl}>
+          {linkAsButton ? (
+            <Button as="a" id={linkId}>
+              {linkText}
+            </Button>
+          ) : (
+            <Text as="a" id={linkId} color="blue_700">
+              {linkText}
+            </Text>
+          )}
+        </Link>
+      ) : null,
+      variant: linkAsButton && "button",
     })
   )
   const titleText = (

--- a/src/components/partials/SliceZone/components/PlansPricesSlice/index.js
+++ b/src/components/partials/SliceZone/components/PlansPricesSlice/index.js
@@ -24,8 +24,7 @@ const PlansPricesSlice = ({ slice }) => {
       features,
       buttonText,
       buttonLink,
-      buttonColor,
-      buttonBackground,
+      buttonId,
       buttonIsPrimary,
       background: cardBackground,
       ...props
@@ -33,12 +32,13 @@ const PlansPricesSlice = ({ slice }) => {
       ...props,
       background: cardBackground,
       features: features && <RichText render={features} />,
-      button: buttonText && buttonLink && (
+      button: buttonText && (
         <Link link={buttonLink}>
           <Button
             forwardedAs="a"
             variant={buttonIsPrimary ? "primary" : "default"}
             background={cardBackground}
+            id={buttonId}
           >
             {buttonText}
           </Button>

--- a/src/types/info.json
+++ b/src/types/info.json
@@ -50,6 +50,13 @@
             },
             "type" : "Text"
           },
+          "buttonId" : {
+            "config" : {
+              "label" : "Button selector ID (optional)",
+              "placeholder" : "ID selector for external tools (eg: navbar_button_overview)"
+            },
+            "type" : "Text"
+          },
           "primary" : {
             "type" : "Boolean",
             "config" : {
@@ -119,6 +126,13 @@
                   "allowTargetBlank" : true,
                   "label" : "Button Link"
                 }
+              },
+              "buttonId" : {
+                "config" : {
+                  "label" : "Button selector ID (optional)",
+                  "placeholder" : "ID selector for external tools (eg: landing_cta_button_10003)"
+                },
+                "type" : "Text"
               },
               "background" : {
                 "type" : "Select",
@@ -363,6 +377,13 @@
                   "label" : "Primary Button Link"
                 }
               },
+              "primaryButtonId" : {
+                "config" : {
+                  "label" : "Primary button selector ID (optional)",
+                  "placeholder" : "ID selector for external tools (eg: features_100003_hero_button_1)"
+                },
+                "type" : "Text"
+              },
               "secondaryButtonText" : {
                 "type" : "Text",
                 "config" : {
@@ -376,6 +397,13 @@
                   "allowTargetBlank" : true,
                   "label" : "Secondary Button Link"
                 }
+              },
+              "secondaryButtonId" : {
+                "config" : {
+                  "label" : "Secondary button selector ID (optional)",
+                  "placeholder" : "ID selector for external tools (eg: features_100003_hero_button_2)"
+                },
+                "type" : "Text"
               }
             },
             "repeat" : { }
@@ -670,6 +698,13 @@
                 },
                 "type" : "Link"
               },
+              "linkId" : {
+                "config" : {
+                  "label" : "Link selector ID (optional)",
+                  "placeholder" : "ID selector for external tools (eg: features_link_pay_any_landlord)"
+                },
+                "type" : "Text"
+              },
               "linkAsButton" : {
                 "type" : "Boolean",
                 "config" : {
@@ -827,6 +862,13 @@
                   "allowTargetBlank" : true,
                   "label" : "Button Link"
                 }
+              },
+              "buttonId" : {
+                "config" : {
+                  "label" : "Button selector ID (optional)",
+                  "placeholder" : "ID selector for external tools (eg: screening_plans_extra_button)"
+                },
+                "type" : "Text"
               },
               "buttonIsPrimary" : {
                 "type" : "Boolean",


### PR DESCRIPTION
Two components to this:

- Removes requirement to have an actual URL for most of the buttons, so that editors can make so called "action buttons"
- Adds ability to specify an ID for buttons, so that these "action buttons" can be deterministically targeted by scripts in Digioh and/or Google Tag Manager, etc