### PR TITLE
Temporary solution to remove the a:link style tag

### DIFF
--- a/pages/_document.js
+++ b/pages/_document.js
@@ -90,6 +90,26 @@ export default class Document extends NextDoc {
           <Main />
           <NextScript />
         </body>
+        {/**
+            The script bellow was inserted as an urgent and **temporary** fix
+            to solve the bug 'Prismic Primary Button Variation only displays
+            text on hover' that was affecting the CMS production environment.
+        */}
+        <script
+          dangerouslySetInnerHTML={{
+            __html: `!function(){
+              function removeAlinkStyle(retryDelay) {
+                const alinkStyles = Array.from(document.head.querySelectorAll("style")).filter(e => e.innerHTML.includes("a:link"));
+                if (alinkStyles.length) {
+                  alinkStyles.forEach(node => node.remove());
+                } else if (retryDelay < 2000) {
+                  setTimeout(() => removeAlinkStyle(retryDelay * 3), retryDelay);
+                }
+              }
+              setTimeout(() => removeAlinkStyle(50), 50);
+            }();`.replace(/(\r\n|\n|\r|\t)/gm, ""),
+          }}
+        />
       </Html>
     )
   }

--- a/pages/_document.js
+++ b/pages/_document.js
@@ -50,17 +50,6 @@ export default class Document extends NextDoc {
               }}
             />
           )}
-          {GTM_CONTAINER_ID && (
-            <script
-              dangerouslySetInnerHTML={{
-                __html: `(function(a,s,y,n,c,h,i,d,e){s.className+=' '+y;h.start=1*new Date;
-          h.end=i=function(){s.className=s.className.replace(RegExp(' ?'+y),'')};
-          (a[n]=a[n]||[]).hide=h;setTimeout(function(){i();h.end=null},c);h.timeout=c;
-          })(window,document.documentElement,'async-hide','dataLayer',4000,
-          {'${GTM_CONTAINER_ID}':true});`.replace(/(\r\n|\n|\r|\t)/gm, ""),
-              }}
-            />
-          )}
           {SEGMENT_KEY && (
             <script
               dangerouslySetInnerHTML={{
@@ -90,26 +79,6 @@ export default class Document extends NextDoc {
           <Main />
           <NextScript />
         </body>
-        {/**
-            The script bellow was inserted as an urgent and **temporary** fix
-            to solve the bug 'Prismic Primary Button Variation only displays
-            text on hover' that was affecting the CMS production environment.
-        */}
-        <script
-          dangerouslySetInnerHTML={{
-            __html: `!function(){
-              function removeAlinkStyle(retryDelay) {
-                const alinkStyles = Array.from(document.head.querySelectorAll("style")).filter(e => e.innerHTML.includes("a:link"));
-                if (alinkStyles.length) {
-                  alinkStyles.forEach(node => node.remove());
-                } else if (retryDelay < 2000) {
-                  setTimeout(() => removeAlinkStyle(retryDelay * 3), retryDelay);
-                }
-              }
-              setTimeout(() => removeAlinkStyle(50), 50);
-            }();`.replace(/(\r\n|\n|\r|\t)/gm, ""),
-          }}
-        />
       </Html>
     )
   }


### PR DESCRIPTION
Link to the issue: https://avail-oc.atlassian.net/servicedesk/customer/portal/4/PS-1567
Reproducible at: https://info.avail.co/info/resources-tenants-renting-information-hub

PR Explanation: **This is not a definitive solution**, but since this bug is currently affecting production mode of the CMS app, I propose we merge and deploy this temporary workaround that will have no impact on the application. This should give us some more time to investigate who is injecting the unwanted style tag on the document head.

I would need access to Vercel deployment information in order to try to check how and what third part libs are being injected on the application and why I can see them on my local dev environment.