### PR TITLE
Fix: Testimonials Slider endless render loop

### DIFF
--- a/src/components/molecules/Slider/index.js
+++ b/src/components/molecules/Slider/index.js
@@ -29,12 +29,7 @@ function Slider({
   })
 
   return (
-    <Box
-      as={motion.aside}
-      {...animation?.item}
-      ref={animationIntersectionView}
-      {...props}
-    >
+    <Box ref={animationIntersectionView} {...props}>
       <Box
         ref={scrollRef}
         sx={{
@@ -56,7 +51,7 @@ function Slider({
               marginRight: "2rem",
             },
           }}
-          forwardedAs={motion.div}
+          as={motion.div}
           {...animation?.container}
         >
           {React.Children.map(children, (child, idx) => (
@@ -74,19 +69,18 @@ function Slider({
           ))}
         </Box>
       </Box>
-      {scrollControl.shouldShow && (
-        <Box
-          sx={{
-            textAlign: "right",
-            "> *": {
-              margin: "1rem",
-            },
-          }}
-        >
-          <ControlChevron as={ChevronLeft} {...scrollControl.leftControl} />
-          <ControlChevron as={ChevronRight} {...scrollControl.rightControl} />
-        </Box>
-      )}
+      <Box
+        sx={{
+          textAlign: "right",
+          "> *": {
+            margin: "1rem",
+          },
+          visibility: scrollControl.shouldShow ? "visible" : "hidden",
+        }}
+      >
+        <ControlChevron as={ChevronLeft} {...scrollControl.leftControl} />
+        <ControlChevron as={ChevronRight} {...scrollControl.rightControl} />
+      </Box>
     </Box>
   )
 }

--- a/src/components/organisms/Testimonials/cards/index.js
+++ b/src/components/organisms/Testimonials/cards/index.js
@@ -25,17 +25,19 @@ function TestimonialsCards({
   return (
     <SkewBox as={motion.aside} {...animation?.container} bg={bg} {...props}>
       <Container ref={containerRef} maxWidth={containerWidth}>
-        <Box
-          as={motion.aside}
-          {...animation?.item}
-          ref={animationIntersectionView}
-        >
+        <Box ref={animationIntersectionView}>
           {title &&
             cloneElement(title, {
               sx: { ...STYLING.headline, ...title?.props?.sx },
               mb: "2rem",
+              as: motion.aside,
+              ...animation?.item,
             })}
-          <Slider containerRef={containerRef}>
+          <Slider
+            as={motion.div}
+            {...animation?.item}
+            containerRef={containerRef}
+          >
             {testimonials?.map(
               ({ picture, author, titleAndLocation, quote: Quote }) => (
                 <Card


### PR DESCRIPTION
When only 3 cards were rendering, the component was entering an endless loop with showing/hiding chevron controls. Using visibility to control the chevron display fixes the loop.