### PR TITLE
Append analytics params to noop script for more robust capture

### DIFF
--- a/src/utils/analytics/index.js
+++ b/src/utils/analytics/index.js
@@ -1,8 +1,5 @@
 import { useCallback, useContext, useEffect, useRef } from "react"
-import {
-  extractTraits,
-  extractTraitsFromLocation,
-} from "utils/analytics/traits"
+import { extractTraits, getSearchParams } from "utils/analytics/traits"
 import { AnalyticsContext } from "utils/analytics/context"
 import { useAnalyticsScript } from "utils/analytics/script"
 
@@ -25,7 +22,7 @@ export function useAnalytics(defaultParams) {
                 ...traits,
                 ...extractTraits({ channel: "direct", ...defaultParams }),
                 ...extractTraits(params),
-                ...extractTraitsFromLocation(locationRef.current),
+                ...extractTraits(getSearchParams(locationRef.current)),
               },
               resolve
             )

--- a/src/utils/analytics/traits.js
+++ b/src/utils/analytics/traits.js
@@ -34,8 +34,7 @@ export function extractTraits(params) {
   }, {})
 }
 
-export function extractTraitsFromLocation(location) {
+export function getSearchParams(location) {
   if (!location?.href) return {}
-  const url = new URL(location.href)
-  return extractTraits(fromEntries(url.searchParams))
+  return fromEntries(new URL(location.href).searchParams)
 }


### PR DESCRIPTION
This will append all the incoming analytics params to `noop.js` call so that `avail.co` will set the all the analytics cookies as soon as possible.